### PR TITLE
Add principal parts and definitions; simplify Lexeme generics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ build/
 .vscode/
 HELP.md
 ../../../Library/Application Support/JetBrains/IntelliJIdea2023.2/scratches/jsonExample.jsonl
+
+*.log
+*.versionsBackup

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.annepolis</groupId>
     <artifactId>lexiconmeum</artifactId>
-    <version>0.1.2-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <name>lexiconmeum</name>
     <description>lexiconmeum</description>
 

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/Inflection.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/Inflection.java
@@ -1,7 +1,9 @@
 package com.annepolis.lexiconmeum.lexeme.detail;
 
-public interface Inflection {
+public interface Inflection <T extends Inflection<T>>{
 
     String getForm();
+    String getAlternativeForm();
+    InflectionBuilder<T> toBuilder();
 
 }

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/Inflection.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/Inflection.java
@@ -1,9 +1,9 @@
 package com.annepolis.lexiconmeum.lexeme.detail;
 
-public interface Inflection <T extends Inflection<T>>{
+public interface Inflection {
 
     String getForm();
     String getAlternativeForm();
-    InflectionBuilder<T> toBuilder();
+    InflectionBuilder toBuilder();
 
 }

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/InflectionBuilder.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/InflectionBuilder.java
@@ -6,5 +6,6 @@ public interface InflectionBuilder<T extends Inflection> {
     T build();
 
     InflectionBuilder<T> setNumber(GrammaticalNumber grammaticalNumber);
+    InflectionBuilder<T> setAlternativeForm(String form);
 }
 

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/InflectionBuilder.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/InflectionBuilder.java
@@ -2,10 +2,10 @@ package com.annepolis.lexiconmeum.lexeme.detail;
 
 import com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalNumber;
 
-public interface InflectionBuilder<T extends Inflection> {
-    T build();
+public interface InflectionBuilder {
+    Inflection build();
 
-    InflectionBuilder<T> setNumber(GrammaticalNumber grammaticalNumber);
-    InflectionBuilder<T> setAlternativeForm(String form);
+    InflectionBuilder setNumber(GrammaticalNumber grammaticalNumber);
+    InflectionBuilder setAlternativeForm(String form);
 }
 

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/LexemeInflectionMapper.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/LexemeInflectionMapper.java
@@ -2,7 +2,7 @@ package com.annepolis.lexiconmeum.lexeme.detail;
 
 import com.annepolis.lexiconmeum.shared.Lexeme;
 
-public interface LexemeInflectionMapper {
+public interface LexemeInflectionMapper<T extends Inflection> {
 
-    InflectionTableDTO toInflectionTableDTO(Lexeme lexeme);
+    InflectionTableDTO toInflectionTableDTO(Lexeme<T> lexeme);
 }

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/LexemeInflectionMapper.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/LexemeInflectionMapper.java
@@ -2,7 +2,7 @@ package com.annepolis.lexiconmeum.lexeme.detail;
 
 import com.annepolis.lexiconmeum.shared.Lexeme;
 
-public interface LexemeInflectionMapper<T extends Inflection> {
+public interface LexemeInflectionMapper {
 
-    InflectionTableDTO toInflectionTableDTO(Lexeme<T> lexeme);
+    InflectionTableDTO toInflectionTableDTO(Lexeme lexeme);
 }

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/grammar/InflectionFeature.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/grammar/InflectionFeature.java
@@ -154,14 +154,14 @@ public enum InflectionFeature {
 
 
     private final String tag;
-    private final Consumer<InflectionBuilder<?>> setter;
+    private final Consumer<InflectionBuilder> setter;
 
-    InflectionFeature(String tag, Consumer<InflectionBuilder<?>> setter) {
+    InflectionFeature(String tag, Consumer<InflectionBuilder> setter) {
         this.tag = tag;
         this.setter = setter;
     }
 
-    public void applyTo(InflectionBuilder<?> d) {
+    public void applyTo(InflectionBuilder d) {
         setter.accept(d);
     }
 

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/noun/Declension.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/noun/Declension.java
@@ -5,7 +5,7 @@ import com.annepolis.lexiconmeum.lexeme.detail.InflectionBuilder;
 import com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalCase;
 import com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalNumber;
 
-public class Declension implements Inflection<Declension> {
+public class Declension implements Inflection {
 
 
     private final String form;
@@ -37,8 +37,8 @@ public class Declension implements Inflection<Declension> {
     }
 
     @Override
-    public InflectionBuilder<Declension> toBuilder() {
-        return new Builder(form)
+    public InflectionBuilder toBuilder() {
+        return new Declension.Builder(form)
                 .setNumber(number)
                 .setGrammaticalCase(grammaticalCase);
     }
@@ -49,7 +49,7 @@ public class Declension implements Inflection<Declension> {
     }
 
 
-    public static class Builder implements InflectionBuilder<Declension> {
+    public static class Builder implements InflectionBuilder {
 
         private GrammaticalNumber number;
         private GrammaticalCase grammaticalCase;
@@ -69,7 +69,7 @@ public class Declension implements Inflection<Declension> {
         }
 
         @Override
-        public InflectionBuilder<Declension> setAlternativeForm(String form) {
+        public InflectionBuilder setAlternativeForm(String form) {
             return this;
         }
 

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/noun/Declension.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/noun/Declension.java
@@ -5,7 +5,7 @@ import com.annepolis.lexiconmeum.lexeme.detail.InflectionBuilder;
 import com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalCase;
 import com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalNumber;
 
-public class Declension implements Inflection {
+public class Declension implements Inflection<Declension> {
 
 
     private final String form;
@@ -14,7 +14,7 @@ public class Declension implements Inflection {
 
     public Declension(Builder builder){
         this.number = builder.getNumber();
-        this.grammaticalCase = builder.grammaticalCase;
+        this.grammaticalCase = builder.getGrammaticalCase();
         this.form = builder.form;
     }
 
@@ -29,6 +29,18 @@ public class Declension implements Inflection {
     @Override
     public String getForm() {
         return form;
+    }
+
+    @Override
+    public String getAlternativeForm() {
+        return null;
+    }
+
+    @Override
+    public InflectionBuilder<Declension> toBuilder() {
+        return new Builder(form)
+                .setNumber(number)
+                .setGrammaticalCase(grammaticalCase);
     }
 
     @Override
@@ -56,6 +68,11 @@ public class Declension implements Inflection {
             return this;
         }
 
+        @Override
+        public InflectionBuilder<Declension> setAlternativeForm(String form) {
+            return this;
+        }
+
         public GrammaticalCase getGrammaticalCase() {
             return grammaticalCase;
         }
@@ -69,7 +86,6 @@ public class Declension implements Inflection {
         public String getForm() {
             return form;
         }
-
 
         @Override
         public Declension build() {

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/noun/LexemeDeclensionMapper.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/noun/LexemeDeclensionMapper.java
@@ -1,6 +1,5 @@
 package com.annepolis.lexiconmeum.lexeme.detail.noun;
 
-import com.annepolis.lexiconmeum.lexeme.detail.Inflection;
 import com.annepolis.lexiconmeum.lexeme.detail.LexemeInflectionMapper;
 import com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalCase;
 import com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalNumber;
@@ -11,22 +10,17 @@ import java.util.EnumMap;
 import java.util.Map;
 
 @Component
-class LexemeDeclensionMapper implements LexemeInflectionMapper {
+class LexemeDeclensionMapper implements LexemeInflectionMapper<Declension> {
 
     @Override
-    public DeclensionTableDTO toInflectionTableDTO(Lexeme lexeme) {
+    public DeclensionTableDTO toInflectionTableDTO(Lexeme<Declension> lexeme) {
 
         Map<GrammaticalNumber, Map<GrammaticalCase, String>> table = new EnumMap<>(GrammaticalNumber.class);
         if(lexeme != null) {
-            for (Inflection inflection : lexeme.getInflections()) {
-                if(inflection instanceof Declension declension){
-                    GrammaticalNumber number = declension.getNumber();
-                    GrammaticalCase grammaticalCase = declension.getGrammaticalCase();
-                    String form = declension.getForm();
+            for (Declension declension : lexeme.getInflections()) {
 
-                    table.computeIfAbsent(number, numberKey -> new EnumMap<>(GrammaticalCase.class))
-                            .put(grammaticalCase, form);
-                }
+                table.computeIfAbsent(declension.getNumber(), numberKey -> new EnumMap<>(GrammaticalCase.class))
+                        .put(declension.getGrammaticalCase(), declension.getForm());
             }
         }
         DeclensionTableDTO dto = new DeclensionTableDTO();

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/noun/LexemeDeclensionMapper.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/noun/LexemeDeclensionMapper.java
@@ -10,18 +10,19 @@ import java.util.EnumMap;
 import java.util.Map;
 
 @Component
-class LexemeDeclensionMapper implements LexemeInflectionMapper<Declension> {
+class LexemeDeclensionMapper implements LexemeInflectionMapper {
 
     @Override
-    public DeclensionTableDTO toInflectionTableDTO(Lexeme<Declension> lexeme) {
+    public DeclensionTableDTO toInflectionTableDTO(Lexeme lexeme) {
 
         Map<GrammaticalNumber, Map<GrammaticalCase, String>> table = new EnumMap<>(GrammaticalNumber.class);
         if(lexeme != null) {
-            for (Declension declension : lexeme.getInflections()) {
-
-                table.computeIfAbsent(declension.getNumber(), numberKey -> new EnumMap<>(GrammaticalCase.class))
-                        .put(declension.getGrammaticalCase(), declension.getForm());
-            }
+            lexeme.getInflections().stream()
+                    .filter(Declension.class::isInstance)
+                    .map(i -> (Declension) i)
+                    .forEach(declension ->
+                        table.computeIfAbsent(declension.getNumber(), n -> new EnumMap<>(GrammaticalCase.class))
+                                .put(declension.getGrammaticalCase(), declension.getForm()));
         }
         DeclensionTableDTO dto = new DeclensionTableDTO();
         dto.setTable(table);

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/noun/LexemeDeclensionService.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/noun/LexemeDeclensionService.java
@@ -18,7 +18,7 @@ public class LexemeDeclensionService {
     }
 
     public DeclensionTableDTO getLexemeDetail(UUID lexemeId) {
-        Lexeme lexeme = lexemeProvider.getLexeme(lexemeId);
+        Lexeme<Declension> lexeme = lexemeProvider.getLexemeOfType(lexemeId, Declension.class);
         return lexemeDeclensionMapper.toInflectionTableDTO(lexeme);
     }
 }

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/noun/LexemeDeclensionService.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/noun/LexemeDeclensionService.java
@@ -18,7 +18,7 @@ public class LexemeDeclensionService {
     }
 
     public DeclensionTableDTO getLexemeDetail(UUID lexemeId) {
-        Lexeme<Declension> lexeme = lexemeProvider.getLexemeOfType(lexemeId, Declension.class);
+        Lexeme lexeme = lexemeProvider.getLexemeOfType(lexemeId, Declension.class);
         return lexemeDeclensionMapper.toInflectionTableDTO(lexeme);
     }
 }

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/Conjugation.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/Conjugation.java
@@ -7,7 +7,7 @@ import com.annepolis.lexiconmeum.lexeme.detail.grammar.*;
 import java.util.ArrayList;
 import java.util.List;
 
-public class Conjugation implements Inflection<Conjugation> {
+public class Conjugation implements Inflection {
 
     private final String form;
     private final String alternativeForm;
@@ -39,7 +39,7 @@ public class Conjugation implements Inflection<Conjugation> {
     }
 
     @Override
-    public InflectionBuilder<Conjugation> toBuilder() {
+    public InflectionBuilder toBuilder() {
         return new Builder(form)
                 .setVoice(voice)
                 .setTense(tense)
@@ -55,7 +55,7 @@ public class Conjugation implements Inflection<Conjugation> {
     public GrammaticalNumber getNumber() { return number; }
     public GrammaticalMood getMood() { return mood; }
 
-    public static class Builder implements InflectionBuilder<Conjugation> {
+    public static class Builder implements InflectionBuilder {
 
         private GrammaticalVoice voice;
         private GrammaticalMood mood;
@@ -137,15 +137,12 @@ public class Conjugation implements Inflection<Conjugation> {
         private void validateFields() {
             List<String> missing = new ArrayList<>();
 
-            if (mood == GrammaticalMood.INFINITIVE) {
-                if (tense == null) missing.add("tense");
-                if (form == null) missing.add("form");
-            } else {
+            if (mood != GrammaticalMood.INFINITIVE) {
                 if (person == null) missing.add("person");
                 if (number == null) missing.add("number");
-                if (tense == null) missing.add("tense");
-                if (form == null) missing.add("form");
             }
+            if (tense == null) missing.add("tense");
+            if (form == null) missing.add("form");
 
             if (!missing.isEmpty()) {
                 throw new IllegalStateException("Missing required fields: " + String.join(", ", missing));

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/Conjugation.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/Conjugation.java
@@ -7,10 +7,10 @@ import com.annepolis.lexiconmeum.lexeme.detail.grammar.*;
 import java.util.ArrayList;
 import java.util.List;
 
-public class Conjugation implements Inflection {
+public class Conjugation implements Inflection<Conjugation> {
 
     private final String form;
-    private final String alternateForm;
+    private final String alternativeForm;
     private final GrammaticalVoice voice;
     private final GrammaticalMood mood;
     private final GrammaticalTense tense;
@@ -25,7 +25,7 @@ public class Conjugation implements Inflection {
         this.person = builder.getPerson();
         this.number = builder.getNumber();
         this.form = builder.getForm();
-        this.alternateForm = builder.getForm();
+        this.alternativeForm = builder.getAlternativeForm();
     }
 
     @Override
@@ -33,22 +33,28 @@ public class Conjugation implements Inflection {
         return form;
     }
 
-    public String getAlternateForm() { return alternateForm; }
-    public GrammaticalVoice getVoice() { return voice; }
-    public GrammaticalTense getTense() { return tense; }
-    public GrammaticalPerson getPerson() { return person;}
-    public GrammaticalNumber getNumber() { return number; }
-    public GrammaticalMood getMood() { return mood; }
+    @Override
+    public String getAlternativeForm() {
+        return alternativeForm;
+    }
 
-    public Builder toBuilder() {
+    @Override
+    public InflectionBuilder<Conjugation> toBuilder() {
         return new Builder(form)
                 .setVoice(voice)
                 .setTense(tense)
                 .setPerson(person)
                 .setNumber(number)
                 .setMood(mood)
-                .setAlternateForm(alternateForm);
+                .setAlternativeForm(alternativeForm);
     }
+
+    public GrammaticalVoice getVoice() { return voice; }
+    public GrammaticalTense getTense() { return tense; }
+    public GrammaticalPerson getPerson() { return person;}
+    public GrammaticalNumber getNumber() { return number; }
+    public GrammaticalMood getMood() { return mood; }
+
     public static class Builder implements InflectionBuilder<Conjugation> {
 
         private GrammaticalVoice voice;
@@ -58,7 +64,7 @@ public class Conjugation implements Inflection {
         private GrammaticalNumber number;
 
         private final String form;
-        private String alternateForm;
+        private String alternativeForm;
 
         public Builder(String form) {
             this.form = form;
@@ -113,12 +119,12 @@ public class Conjugation implements Inflection {
             return form;
         }
 
-        public String getAlternateForm() {
-            return alternateForm;
+        public String getAlternativeForm() {
+            return alternativeForm;
         }
 
-        public Conjugation.Builder setAlternateForm(String alternateForm) {
-            this.alternateForm = alternateForm;
+        public Conjugation.Builder setAlternativeForm(String alternativeForm) {
+            this.alternativeForm = alternativeForm;
             return this;
         }
 

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/InflectionKey.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/InflectionKey.java
@@ -1,0 +1,120 @@
+package com.annepolis.lexiconmeum.lexeme.detail.verb;
+
+import com.annepolis.lexiconmeum.lexeme.detail.Inflection;
+import com.annepolis.lexiconmeum.lexeme.detail.grammar.*;
+import com.annepolis.lexiconmeum.lexeme.detail.noun.Declension;
+import org.springframework.stereotype.Component;
+
+@Component
+public final class InflectionKey {
+
+    public static String of(Inflection<?> inflection){
+        if (inflection instanceof Conjugation c) {
+            return buildConjugationKey(c);
+        } else if (inflection instanceof Declension d ){
+            return buildDeclensionKey(d);
+        } else {
+            throw new IllegalArgumentException("Unsupported inflection type: " + inflection.getClass());
+        }
+    }
+    public static String buildConjugationKey(Conjugation conjugation) {
+        return joinParts(
+                conjugation.getVoice(),
+                conjugation.getMood(),
+                conjugation.getTense(),
+                conjugation.getPerson(),
+                conjugation.getNumber()
+                );
+    }
+
+    public static String joinParts(
+            GrammaticalVoice voice,
+            GrammaticalMood mood,
+            GrammaticalTense tense,
+            GrammaticalPerson person,
+            GrammaticalNumber number
+    ){
+        StringBuilder builder = new StringBuilder();
+        builder.append(buildKeyPart(voice, true));
+        builder.append(buildKeyPart(mood));
+        builder.append(buildKeyPart(tense));
+        builder.append(buildKeyPart(person));
+        builder.append(buildKeyPart(number));
+        return builder.toString();
+    }
+
+    private static String buildKeyPart(Enum<?>  part){
+        return buildKeyPart(part, false);
+    }
+
+    private static String buildKeyPart(Enum<?>  part, boolean firstOne){
+        String delimiter = firstOne ? "" : "|";
+       return part != null ? delimiter + part.name() : "";
+    }
+
+    private static String buildPrinciplePartKey(
+            GrammaticalVoice voice,
+            GrammaticalMood mood,
+            GrammaticalTense tense,
+            GrammaticalPerson person,
+            GrammaticalNumber number
+    ) {
+        return joinParts( voice, mood, tense, person, number );
+    }
+
+    public String buildFirstPrincipalPartKey() {
+        return buildPrinciplePartKey(
+                GrammaticalVoice.ACTIVE,
+                GrammaticalMood.INDICATIVE,
+                GrammaticalTense.PRESENT,
+                GrammaticalPerson.FIRST,
+                GrammaticalNumber.SINGULAR
+        );
+    }
+
+    public String buildSecondPrincipalPartKey() {
+        return buildPrinciplePartKey(
+                GrammaticalVoice.ACTIVE,
+                GrammaticalMood.INFINITIVE,
+                GrammaticalTense.PRESENT,
+                null,
+                null
+        );
+    }
+
+    public String buildThirdPrincipalPartKey() {
+        return buildPrinciplePartKey(
+                GrammaticalVoice.ACTIVE,
+                GrammaticalMood.INDICATIVE,
+                GrammaticalTense.PERFECT,
+                GrammaticalPerson.FIRST,
+                GrammaticalNumber.SINGULAR
+        );
+    }
+
+
+    public static String buildDeclensionKey(Declension declension) {
+        return buildPrinciplePartKey(declension.getGrammaticalCase(), declension.getNumber());
+    }
+
+    public String buildFirstDeclensionPrinciplePartKey(){
+        return buildPrinciplePartKey(GrammaticalCase.NOMINATIVE, GrammaticalNumber.SINGULAR);
+    }
+    public String buildSecondDeclensionPrinciplePartKey(){
+        return buildPrinciplePartKey(GrammaticalCase.GENITIVE, GrammaticalNumber.SINGULAR);
+    }
+
+    private static String buildPrinciplePartKey(
+            GrammaticalCase grammaticalCase,GrammaticalNumber number) {
+        return joinDeclensionParts( grammaticalCase, number  );
+    }
+
+    public static String joinDeclensionParts(
+            GrammaticalCase grammaticalCase, GrammaticalNumber number ) {
+
+        StringBuilder builder = new StringBuilder();
+        builder.append(buildKeyPart(grammaticalCase, true));
+        builder.append(buildKeyPart(number));
+        return builder.toString();
+    }
+}

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/InflectionKey.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/InflectionKey.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 @Component
 public final class InflectionKey {
 
-    public static String of(Inflection<?> inflection){
+    public static String of(Inflection inflection){
         if (inflection instanceof Conjugation c) {
             return buildConjugationKey(c);
         } else if (inflection instanceof Declension d ){
@@ -34,13 +34,11 @@ public final class InflectionKey {
             GrammaticalPerson person,
             GrammaticalNumber number
     ){
-        StringBuilder builder = new StringBuilder();
-        builder.append(buildKeyPart(voice, true));
-        builder.append(buildKeyPart(mood));
-        builder.append(buildKeyPart(tense));
-        builder.append(buildKeyPart(person));
-        builder.append(buildKeyPart(number));
-        return builder.toString();
+        return buildKeyPart(voice, true)
+        + buildKeyPart(mood)
+        + buildKeyPart(tense)
+        + buildKeyPart(person)
+        + buildKeyPart(number);
     }
 
     private static String buildKeyPart(Enum<?>  part){
@@ -112,9 +110,7 @@ public final class InflectionKey {
     public static String joinDeclensionParts(
             GrammaticalCase grammaticalCase, GrammaticalNumber number ) {
 
-        StringBuilder builder = new StringBuilder();
-        builder.append(buildKeyPart(grammaticalCase, true));
-        builder.append(buildKeyPart(number));
-        return builder.toString();
+        return buildKeyPart(grammaticalCase, true)
+        + buildKeyPart(number);
     }
 }

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationDetailDTO.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationDetailDTO.java
@@ -7,17 +7,17 @@ import java.util.List;
 
 public class LexemeConjugationDetailDTO {
 
-    List<String> principleParts = new ArrayList<>();
+    List<String> principalParts = new ArrayList<>();
     List<String> definitions = new ArrayList<>();
 
     InflectionTableDTO inflectionTableDTO;
 
     public List<String> getPrincipleParts() {
-        return principleParts;
+        return principalParts;
     }
 
-    public void addPrinciplePart(String principlePart) {
-        this.getPrincipleParts().add(principlePart);
+    public void addPrinciplePart(String principalPart) {
+        this.getPrincipleParts().add(principalPart);
     }
 
     public List<String> getDefinitions() {

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationDetailDTO.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationDetailDTO.java
@@ -1,0 +1,38 @@
+package com.annepolis.lexiconmeum.lexeme.detail.verb;
+
+import com.annepolis.lexiconmeum.lexeme.detail.InflectionTableDTO;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LexemeConjugationDetailDTO {
+
+    List<String> principleParts = new ArrayList<>();
+    List<String> definitions = new ArrayList<>();
+
+    InflectionTableDTO inflectionTableDTO;
+
+    public List<String> getPrincipleParts() {
+        return principleParts;
+    }
+
+    public void addPrinciplePart(String principlePart) {
+        this.getPrincipleParts().add(principlePart);
+    }
+
+    public List<String> getDefinitions() {
+        return definitions;
+    }
+
+    public void addDefinition(String definition) {
+        this.getDefinitions().add(definition);
+    }
+
+    public InflectionTableDTO getInflectionTableDTO() {
+        return inflectionTableDTO;
+    }
+
+    public void setInflectionTableDTO(InflectionTableDTO inflectionTableDTO) {
+        this.inflectionTableDTO = inflectionTableDTO;
+    }
+}

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationDetailMapper.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationDetailMapper.java
@@ -1,5 +1,6 @@
 package com.annepolis.lexiconmeum.lexeme.detail.verb;
 
+import com.annepolis.lexiconmeum.lexeme.detail.Inflection;
 import com.annepolis.lexiconmeum.lexeme.detail.InflectionTableDTO;
 import com.annepolis.lexiconmeum.lexeme.detail.LexemeInflectionMapper;
 import com.annepolis.lexiconmeum.shared.Lexeme;
@@ -14,14 +15,14 @@ import java.util.Optional;
 public class LexemeConjugationDetailMapper {
 
     InflectionKey inflectionKey;
-    LexemeInflectionMapper<Conjugation> lexemeConjugationMapper;
+    LexemeInflectionMapper lexemeConjugationMapper;
 
-    LexemeConjugationDetailMapper(LexemeInflectionMapper<Conjugation> lexemeConjugationMapper, InflectionKey inflectionKey){
+    LexemeConjugationDetailMapper(LexemeInflectionMapper lexemeConjugationMapper, InflectionKey inflectionKey){
         this.inflectionKey = inflectionKey;
         this.lexemeConjugationMapper = lexemeConjugationMapper;
     }
 
-    LexemeConjugationDetailDTO toLexemeDetailDTO(Lexeme<Conjugation> lexeme){
+    LexemeConjugationDetailDTO toLexemeDetailDTO(Lexeme lexeme){
         LexemeConjugationDetailDTO dto = new LexemeConjugationDetailDTO();
         populateDefinitions(dto, lexeme.getSenses());
 
@@ -35,24 +36,24 @@ public class LexemeConjugationDetailMapper {
                 .toList().forEach(dto::addDefinition);
     }
 
-    void populatePrincipleParts(LexemeConjugationDetailDTO dto, Map<String, Conjugation> inflectionIndex) {
+    void populatePrincipleParts(LexemeConjugationDetailDTO dto, Map<String, Inflection> inflectionIndex) {
         Optional.ofNullable(inflectionIndex.get(inflectionKey.buildFirstPrincipalPartKey()))
-                .map(Conjugation::getForm)
+                .map(Inflection::getForm)
                 .filter(form -> !form.isBlank())
                 .ifPresent(dto::addPrinciplePart);
 
         Optional.ofNullable(inflectionIndex.get(inflectionKey.buildSecondPrincipalPartKey()))
-                .map(Conjugation::getForm)
+                .map(Inflection::getForm)
                 .filter(form -> !form.isBlank()) // Optional: skip blank forms
                 .ifPresent(dto::addPrinciplePart);
 
         Optional.ofNullable(inflectionIndex.get(inflectionKey.buildThirdPrincipalPartKey()))
-                .map(Conjugation::getForm)
+                .map(Inflection::getForm)
                 .filter(form -> !form.isBlank()) // Optional: skip blank forms
                 .ifPresent(dto::addPrinciplePart);
     }
 
-    void populateInflectionTable(LexemeConjugationDetailDTO dto, Lexeme<Conjugation> lexeme){
+    void populateInflectionTable(LexemeConjugationDetailDTO dto, Lexeme lexeme){
         InflectionTableDTO tableDTO = lexemeConjugationMapper.toInflectionTableDTO(lexeme);
         dto.setInflectionTableDTO(tableDTO);
     }

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationDetailMapper.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationDetailMapper.java
@@ -1,6 +1,5 @@
 package com.annepolis.lexiconmeum.lexeme.detail.verb;
 
-import com.annepolis.lexiconmeum.lexeme.detail.Inflection;
 import com.annepolis.lexiconmeum.lexeme.detail.InflectionTableDTO;
 import com.annepolis.lexiconmeum.lexeme.detail.LexemeInflectionMapper;
 import com.annepolis.lexiconmeum.shared.Lexeme;
@@ -10,20 +9,19 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Component
 public class LexemeConjugationDetailMapper {
 
     InflectionKey inflectionKey;
-    LexemeInflectionMapper lexemeConjugationMapper;
+    LexemeInflectionMapper<Conjugation> lexemeConjugationMapper;
 
-    LexemeConjugationDetailMapper(LexemeInflectionMapper lexemeConjugationMapper, InflectionKey inflectionKey){
+    LexemeConjugationDetailMapper(LexemeInflectionMapper<Conjugation> lexemeConjugationMapper, InflectionKey inflectionKey){
         this.inflectionKey = inflectionKey;
         this.lexemeConjugationMapper = lexemeConjugationMapper;
     }
 
-    LexemeConjugationDetailDTO toLexemeDetailDTO(Lexeme lexeme){
+    LexemeConjugationDetailDTO toLexemeDetailDTO(Lexeme<Conjugation> lexeme){
         LexemeConjugationDetailDTO dto = new LexemeConjugationDetailDTO();
         populateDefinitions(dto, lexeme.getSenses());
 
@@ -34,27 +32,27 @@ public class LexemeConjugationDetailMapper {
 
     void populateDefinitions(LexemeConjugationDetailDTO dto, List<Sense> senses){
         senses.stream().flatMap(s -> s.getGloss().stream())
-                .collect(Collectors.toList()).forEach(dto::addDefinition);
+                .toList().forEach(dto::addDefinition);
     }
 
-    void populatePrincipleParts(LexemeConjugationDetailDTO dto, Map<String, Inflection> inflectionIndex) {
+    void populatePrincipleParts(LexemeConjugationDetailDTO dto, Map<String, Conjugation> inflectionIndex) {
         Optional.ofNullable(inflectionIndex.get(inflectionKey.buildFirstPrincipalPartKey()))
-                .map(Inflection::getForm)
+                .map(Conjugation::getForm)
                 .filter(form -> !form.isBlank())
                 .ifPresent(dto::addPrinciplePart);
 
         Optional.ofNullable(inflectionIndex.get(inflectionKey.buildSecondPrincipalPartKey()))
-                .map(Inflection::getForm)
+                .map(Conjugation::getForm)
                 .filter(form -> !form.isBlank()) // Optional: skip blank forms
                 .ifPresent(dto::addPrinciplePart);
 
         Optional.ofNullable(inflectionIndex.get(inflectionKey.buildThirdPrincipalPartKey()))
-                .map(Inflection::getForm)
+                .map(Conjugation::getForm)
                 .filter(form -> !form.isBlank()) // Optional: skip blank forms
                 .ifPresent(dto::addPrinciplePart);
     }
 
-    void populateInflectionTable(LexemeConjugationDetailDTO dto, Lexeme lexeme){
+    void populateInflectionTable(LexemeConjugationDetailDTO dto, Lexeme<Conjugation> lexeme){
         InflectionTableDTO tableDTO = lexemeConjugationMapper.toInflectionTableDTO(lexeme);
         dto.setInflectionTableDTO(tableDTO);
     }

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationDetailMapper.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationDetailMapper.java
@@ -1,0 +1,63 @@
+package com.annepolis.lexiconmeum.lexeme.detail.verb;
+
+import com.annepolis.lexiconmeum.lexeme.detail.Inflection;
+import com.annepolis.lexiconmeum.lexeme.detail.InflectionTableDTO;
+import com.annepolis.lexiconmeum.lexeme.detail.LexemeInflectionMapper;
+import com.annepolis.lexiconmeum.shared.Lexeme;
+import com.annepolis.lexiconmeum.shared.Sense;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Component
+public class LexemeConjugationDetailMapper {
+
+    InflectionKey inflectionKey;
+    LexemeInflectionMapper lexemeConjugationMapper;
+
+    LexemeConjugationDetailMapper(LexemeInflectionMapper lexemeConjugationMapper, InflectionKey inflectionKey){
+        this.inflectionKey = inflectionKey;
+        this.lexemeConjugationMapper = lexemeConjugationMapper;
+    }
+
+    LexemeConjugationDetailDTO toLexemeDetailDTO(Lexeme lexeme){
+        LexemeConjugationDetailDTO dto = new LexemeConjugationDetailDTO();
+        populateDefinitions(dto, lexeme.getSenses());
+
+        populatePrincipleParts(dto, lexeme.getInflectionIndex());
+        populateInflectionTable(dto, lexeme);
+        return dto;
+    }
+
+    void populateDefinitions(LexemeConjugationDetailDTO dto, List<Sense> senses){
+        senses.stream().flatMap(s -> s.getGloss().stream())
+                .collect(Collectors.toList()).forEach(dto::addDefinition);
+    }
+
+    void populatePrincipleParts(LexemeConjugationDetailDTO dto, Map<String, Inflection> inflectionIndex) {
+        Optional.ofNullable(inflectionIndex.get(inflectionKey.buildFirstPrincipalPartKey()))
+                .map(Inflection::getForm)
+                .filter(form -> !form.isBlank())
+                .ifPresent(dto::addPrinciplePart);
+
+        Optional.ofNullable(inflectionIndex.get(inflectionKey.buildSecondPrincipalPartKey()))
+                .map(Inflection::getForm)
+                .filter(form -> !form.isBlank()) // Optional: skip blank forms
+                .ifPresent(dto::addPrinciplePart);
+
+        Optional.ofNullable(inflectionIndex.get(inflectionKey.buildThirdPrincipalPartKey()))
+                .map(Inflection::getForm)
+                .filter(form -> !form.isBlank()) // Optional: skip blank forms
+                .ifPresent(dto::addPrinciplePart);
+    }
+
+    void populateInflectionTable(LexemeConjugationDetailDTO dto, Lexeme lexeme){
+        InflectionTableDTO tableDTO = lexemeConjugationMapper.toInflectionTableDTO(lexeme);
+        dto.setInflectionTableDTO(tableDTO);
+    }
+
+
+}

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationMapper.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationMapper.java
@@ -11,7 +11,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @Component
-class LexemeConjugationMapper implements LexemeInflectionMapper {
+class LexemeConjugationMapper implements LexemeInflectionMapper<Conjugation> {
 
     static Comparator<ConjugationTableDTO> conjugationTableDTOComparator =
             Comparator.comparing(LexemeConjugationMapper::resolveVoiceOrder)
@@ -74,7 +74,7 @@ class LexemeConjugationMapper implements LexemeInflectionMapper {
         return dto;
     }
 
-    List<Conjugation> extractConjugations(Lexeme lexeme){
+    List<Conjugation> extractConjugations(Lexeme<Conjugation> lexeme){
         List<Conjugation> conjugations = lexeme.getInflections().stream()
                .filter(Conjugation.class::isInstance)
                .map(Conjugation.class::cast)

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationMapper.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationMapper.java
@@ -11,7 +11,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @Component
-public class LexemeConjugationMapper implements LexemeInflectionMapper {
+class LexemeConjugationMapper implements LexemeInflectionMapper {
 
     static Comparator<ConjugationTableDTO> conjugationTableDTOComparator =
             Comparator.comparing(LexemeConjugationMapper::resolveVoiceOrder)

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationMapper.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationMapper.java
@@ -11,7 +11,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @Component
-class LexemeConjugationMapper implements LexemeInflectionMapper<Conjugation> {
+class LexemeConjugationMapper implements LexemeInflectionMapper {
 
     static Comparator<ConjugationTableDTO> conjugationTableDTOComparator =
             Comparator.comparing(LexemeConjugationMapper::resolveVoiceOrder)
@@ -74,7 +74,7 @@ class LexemeConjugationMapper implements LexemeInflectionMapper<Conjugation> {
         return dto;
     }
 
-    List<Conjugation> extractConjugations(Lexeme<Conjugation> lexeme){
+    List<Conjugation> extractConjugations(Lexeme lexeme){
         List<Conjugation> conjugations = lexeme.getInflections().stream()
                .filter(Conjugation.class::isInstance)
                .map(Conjugation.class::cast)

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationService.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationService.java
@@ -19,7 +19,7 @@ public class LexemeConjugationService {
     }
 
     public LexemeConjugationDetailDTO getLexemeDetail(UUID lexemeId) {
-        Lexeme<Conjugation> lexeme = lexemeProvider.getLexemeOfType(lexemeId, Conjugation.class);
+        Lexeme lexeme = lexemeProvider.getLexemeOfType(lexemeId, Conjugation.class);
         return lexemeConjugationDetailMapper.toLexemeDetailDTO(lexeme);
 
     }

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationService.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationService.java
@@ -19,7 +19,7 @@ public class LexemeConjugationService {
     }
 
     public LexemeConjugationDetailDTO getLexemeDetail(UUID lexemeId) {
-        Lexeme lexeme = lexemeProvider.getLexeme(lexemeId);
+        Lexeme<Conjugation> lexeme = lexemeProvider.getLexemeOfType(lexemeId, Conjugation.class);
         return lexemeConjugationDetailMapper.toLexemeDetailDTO(lexeme);
 
     }

--- a/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationService.java
+++ b/src/main/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationService.java
@@ -10,17 +10,18 @@ import java.util.UUID;
 @Service
 public class LexemeConjugationService {
 
-    private final LexemeConjugationMapper lexemeConjugationMapper;
+    private final LexemeConjugationDetailMapper lexemeConjugationDetailMapper;
     private final LexemeProvider lexemeProvider;
 
-    public LexemeConjugationService(LexemeProvider lexemeProvider, LexemeConjugationMapper lexemeConjugationMapper){
-        this.lexemeConjugationMapper = lexemeConjugationMapper;
+    public LexemeConjugationService(LexemeProvider lexemeProvider, LexemeConjugationDetailMapper lexemeConjugationDetailMapper){
+        this.lexemeConjugationDetailMapper = lexemeConjugationDetailMapper;
         this.lexemeProvider = lexemeProvider;
     }
 
-    public ConjugationGroupDTO getLexemeDetail(UUID lexemeId) {
+    public LexemeConjugationDetailDTO getLexemeDetail(UUID lexemeId) {
         Lexeme lexeme = lexemeProvider.getLexeme(lexemeId);
-        return lexemeConjugationMapper.toInflectionTableDTO(lexeme);
+        return lexemeConjugationDetailMapper.toLexemeDetailDTO(lexeme);
+
     }
 
 }

--- a/src/main/java/com/annepolis/lexiconmeum/shared/Lexeme.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/Lexeme.java
@@ -8,15 +8,15 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
-public class Lexeme<T extends Inflection> {
+public class Lexeme {
 
     private final UUID id;
     private final String lemma;
     private final GrammaticalPosition position;
     private final List<Sense> senses;
-    private final Map<String, T> inflections;
+    private final Map<String, Inflection> inflections;
 
-    Lexeme(LexemeBuilder<T> builder ) {
+    Lexeme(LexemeBuilder builder ) {
         this.lemma = builder.getLemma();
         this.position = builder.getPosition();
         this.id = builder.getId();
@@ -34,11 +34,11 @@ public class Lexeme<T extends Inflection> {
         return position;
     }
 
-    public List<T> getInflections(){
+    public List<Inflection> getInflections(){
         return inflections.values().stream().toList();
     }
 
-    public Map<String, T> getInflectionIndex(){
+    public Map<String, Inflection> getInflectionIndex(){
         return inflections;
     }
 
@@ -48,7 +48,7 @@ public class Lexeme<T extends Inflection> {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        Lexeme<T> lexeme = (Lexeme) o;
+        Lexeme lexeme = (Lexeme) o;
         return Objects.equals(lemma, lexeme.lemma) && Objects.equals(position, lexeme.position);
     }
 

--- a/src/main/java/com/annepolis/lexiconmeum/shared/Lexeme.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/Lexeme.java
@@ -4,6 +4,7 @@ import com.annepolis.lexiconmeum.lexeme.detail.Inflection;
 import com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalPosition;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -13,7 +14,7 @@ public class Lexeme {
     private final String lemma;
     private final GrammaticalPosition position;
     private final List<Sense> senses;
-    private final List<Inflection> inflections;
+    private final Map<String, Inflection> inflections;
 
     Lexeme(LexemeBuilder builder ) {
         this.lemma = builder.getLemma();
@@ -34,6 +35,10 @@ public class Lexeme {
     }
 
     public List<Inflection> getInflections(){
+        return inflections.values().stream().toList();
+    }
+
+    public Map<String, Inflection> getInflectionIndex(){
         return inflections;
     }
 

--- a/src/main/java/com/annepolis/lexiconmeum/shared/Lexeme.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/Lexeme.java
@@ -8,15 +8,15 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
-public class Lexeme {
+public class Lexeme<T extends Inflection> {
 
     private final UUID id;
     private final String lemma;
     private final GrammaticalPosition position;
     private final List<Sense> senses;
-    private final Map<String, Inflection> inflections;
+    private final Map<String, T> inflections;
 
-    Lexeme(LexemeBuilder builder ) {
+    Lexeme(LexemeBuilder<T> builder ) {
         this.lemma = builder.getLemma();
         this.position = builder.getPosition();
         this.id = builder.getId();
@@ -34,11 +34,11 @@ public class Lexeme {
         return position;
     }
 
-    public List<Inflection> getInflections(){
+    public List<T> getInflections(){
         return inflections.values().stream().toList();
     }
 
-    public Map<String, Inflection> getInflectionIndex(){
+    public Map<String, T> getInflectionIndex(){
         return inflections;
     }
 
@@ -48,7 +48,7 @@ public class Lexeme {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        Lexeme lexeme = (Lexeme) o;
+        Lexeme<T> lexeme = (Lexeme) o;
         return Objects.equals(lemma, lexeme.lemma) && Objects.equals(position, lexeme.position);
     }
 

--- a/src/main/java/com/annepolis/lexiconmeum/shared/LexemeBuilder.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/LexemeBuilder.java
@@ -1,7 +1,6 @@
 package com.annepolis.lexiconmeum.shared;
 
 import com.annepolis.lexiconmeum.lexeme.detail.Inflection;
-import com.annepolis.lexiconmeum.lexeme.detail.InflectionBuilder;
 import com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalGender;
 import com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalPosition;
 import com.annepolis.lexiconmeum.lexeme.detail.verb.InflectionKey;
@@ -9,14 +8,14 @@ import com.annepolis.lexiconmeum.lexeme.detail.verb.InflectionKey;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
-public class LexemeBuilder<T extends Inflection> {
+public class LexemeBuilder {
 
     private final UUID id;
     private final String lemma;
     private final GrammaticalPosition position;
     private GrammaticalGender gender;
     private final List<Sense> senses = new ArrayList<>();
-    private final Map<String, T> inflectionIndex = new HashMap<>();
+    private final Map<String, Inflection> inflectionIndex = new HashMap<>();
 
     public LexemeBuilder(String lemma, GrammaticalPosition position){
         this.lemma = lemma;
@@ -44,7 +43,7 @@ public class LexemeBuilder<T extends Inflection> {
         return this.position;
     }
 
-    public LexemeBuilder<T> setGender(GrammaticalGender gender){
+    public LexemeBuilder setGender(GrammaticalGender gender){
         this.gender = gender;
         return this;
     }
@@ -53,7 +52,7 @@ public class LexemeBuilder<T extends Inflection> {
         return gender;
     }
 
-    public LexemeBuilder<T> addSense(Sense sense){
+    public LexemeBuilder addSense(Sense sense){
         this.senses.add(sense);
         return this;
     }
@@ -62,12 +61,15 @@ public class LexemeBuilder<T extends Inflection> {
         return senses;
     }
 
-    public LexemeBuilder<T> addInflection(T inflection){
+    public LexemeBuilder addInflection(Inflection inflection){
         String key = InflectionKey.of(inflection);
         if (inflectionIndex.containsKey(key)) {
-            T existing = inflectionIndex.get(key);
-            InflectionBuilder<T>  builder = existing.toBuilder();
-            T updated = builder.setAlternativeForm(inflection.getForm()).build();
+            Inflection existing = inflectionIndex.get(key);
+            Inflection updated = existing
+                    .toBuilder()
+                    .setAlternativeForm(inflection.getForm())
+                    .build();
+
             inflectionIndex.put(key, updated);
         } else {
             inflectionIndex.put(key, inflection);
@@ -75,12 +77,12 @@ public class LexemeBuilder<T extends Inflection> {
         return this;
     }
 
-    public Map<String,T> getInflections() {
+    public Map<String,Inflection> getInflections() {
         return inflectionIndex;
     }
 
 
-    public Lexeme<T> build(){
+    public Lexeme build(){
 
         if (lemma == null || position == null) {
             throw new IllegalStateException("Missing required fields: " +
@@ -88,7 +90,7 @@ public class LexemeBuilder<T extends Inflection> {
                     (position == null ? "position " : ""));
         }
 
-        return new Lexeme<>(this);
+        return new Lexeme(this);
     }
 
 

--- a/src/main/java/com/annepolis/lexiconmeum/shared/LexemeBuilder.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/LexemeBuilder.java
@@ -16,7 +16,7 @@ public class LexemeBuilder<T extends Inflection> {
     private final GrammaticalPosition position;
     private GrammaticalGender gender;
     private final List<Sense> senses = new ArrayList<>();
-    private Map<String, T> inflectionIndex = new HashMap<>();
+    private final Map<String, T> inflectionIndex = new HashMap<>();
 
     public LexemeBuilder(String lemma, GrammaticalPosition position){
         this.lemma = lemma;
@@ -44,7 +44,7 @@ public class LexemeBuilder<T extends Inflection> {
         return this.position;
     }
 
-    public LexemeBuilder setGender(GrammaticalGender gender){
+    public LexemeBuilder<T> setGender(GrammaticalGender gender){
         this.gender = gender;
         return this;
     }
@@ -53,7 +53,7 @@ public class LexemeBuilder<T extends Inflection> {
         return gender;
     }
 
-    public LexemeBuilder addSense(Sense sense){
+    public LexemeBuilder<T> addSense(Sense sense){
         this.senses.add(sense);
         return this;
     }
@@ -80,7 +80,7 @@ public class LexemeBuilder<T extends Inflection> {
     }
 
 
-    public Lexeme build(){
+    public Lexeme<T> build(){
 
         if (lemma == null || position == null) {
             throw new IllegalStateException("Missing required fields: " +
@@ -88,7 +88,7 @@ public class LexemeBuilder<T extends Inflection> {
                     (position == null ? "position " : ""));
         }
 
-        return new Lexeme(this);
+        return new Lexeme<>(this);
     }
 
 

--- a/src/main/java/com/annepolis/lexiconmeum/shared/LexemeBuilder.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/LexemeBuilder.java
@@ -1,22 +1,22 @@
 package com.annepolis.lexiconmeum.shared;
 
 import com.annepolis.lexiconmeum.lexeme.detail.Inflection;
+import com.annepolis.lexiconmeum.lexeme.detail.InflectionBuilder;
 import com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalGender;
 import com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalPosition;
+import com.annepolis.lexiconmeum.lexeme.detail.verb.InflectionKey;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
-public class LexemeBuilder {
+public class LexemeBuilder<T extends Inflection> {
 
     private final UUID id;
     private final String lemma;
     private final GrammaticalPosition position;
     private GrammaticalGender gender;
     private final List<Sense> senses = new ArrayList<>();
-    private List<Inflection> inflections = new ArrayList<>();
+    private Map<String, T> inflectionIndex = new HashMap<>();
 
     public LexemeBuilder(String lemma, GrammaticalPosition position){
         this.lemma = lemma;
@@ -62,19 +62,23 @@ public class LexemeBuilder {
         return senses;
     }
 
-    public LexemeBuilder setInflectionList(List<Inflection> inflectionList){
-        this.inflections = inflectionList;
+    public LexemeBuilder<T> addInflection(T inflection){
+        String key = InflectionKey.of(inflection);
+        if (inflectionIndex.containsKey(key)) {
+            T existing = inflectionIndex.get(key);
+            InflectionBuilder<T>  builder = existing.toBuilder();
+            T updated = builder.setAlternativeForm(inflection.getForm()).build();
+            inflectionIndex.put(key, updated);
+        } else {
+            inflectionIndex.put(key, inflection);
+        }
         return this;
     }
 
-    public LexemeBuilder addInflection(Inflection inflection){
-        this.inflections.add(inflection);
-        return this;
+    public Map<String,T> getInflections() {
+        return inflectionIndex;
     }
 
-    public List<Inflection> getInflections() {
-        return inflections;
-    }
 
     public Lexeme build(){
 

--- a/src/main/java/com/annepolis/lexiconmeum/shared/LexemeCache.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/LexemeCache.java
@@ -15,31 +15,29 @@ public class LexemeCache implements LexemeSink, LexemeProvider {
 
     static final Logger logger = LogManager.getLogger(LexemeCache.class);
 
-    private final HashMap<UUID, Lexeme<?>> lexemeIdToLexemeLookup = new HashMap<>();
+    private final HashMap<UUID, Lexeme> lexemeIdToLexemeLookup = new HashMap<>();
 
 
     @Override
-    public Optional<Lexeme<?>> getLexemeIfPresent(UUID lexemeId) {
+    public Optional<Lexeme> getLexemeIfPresent(UUID lexemeId) {
         return Optional.ofNullable(lexemeIdToLexemeLookup.get(lexemeId));
     }
 
     @Override
-    public <T extends Inflection> Lexeme<T> getLexemeOfType(UUID lexemeId, Class<T> expectedType) {
-        Lexeme<?> lexeme = lexemeIdToLexemeLookup.get(lexemeId);
+    public <T extends Inflection> Lexeme getLexemeOfType(UUID lexemeId, Class<T> expectedType) {
+        Lexeme lexeme = lexemeIdToLexemeLookup.get(lexemeId);
 
         boolean matches = lexeme.getInflections().stream().allMatch(expectedType::isInstance);
         if (!matches) {
             throw new LexemeTypeMismatchException("Expected lexeme of type " + expectedType.getSimpleName());
         }
 
-        @SuppressWarnings("unchecked")
-        Lexeme<T> typedLexeme = (Lexeme<T>) lexeme;
-        return typedLexeme;
+        return lexeme;
     }
 
 
 
-    void addLexeme(Lexeme<?> lexeme){
+    void addLexeme(Lexeme lexeme){
         if(logger.isDebugEnabled()) {
             logger.trace("accepting lexeme: {}", lexeme);
         }

--- a/src/main/java/com/annepolis/lexiconmeum/shared/LexemeProvider.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/LexemeProvider.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 public interface LexemeProvider {
 
     @SuppressWarnings("java:S1452")
-    Optional<Lexeme<?>> getLexemeIfPresent(UUID lemmaId);
-    <T extends Inflection> Lexeme<T> getLexemeOfType(UUID lemmaId, Class<T> expectedType);
+    Optional<Lexeme> getLexemeIfPresent(UUID lemmaId);
+    <T extends Inflection> Lexeme getLexemeOfType(UUID lemmaId, Class<T> expectedType);
 
 }

--- a/src/main/java/com/annepolis/lexiconmeum/shared/LexemeProvider.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/LexemeProvider.java
@@ -1,11 +1,14 @@
 package com.annepolis.lexiconmeum.shared;
 
+import com.annepolis.lexiconmeum.lexeme.detail.Inflection;
+
 import java.util.Optional;
 import java.util.UUID;
 
 public interface LexemeProvider {
 
-    Lexeme getLexeme(UUID lemma);
+    @SuppressWarnings("java:S1452")
+    Optional<Lexeme<?>> getLexemeIfPresent(UUID lemmaId);
+    <T extends Inflection> Lexeme<T> getLexemeOfType(UUID lemmaId, Class<T> expectedType);
 
-    Optional<Lexeme> getLexemeIfPresent(UUID lemmaId);
 }

--- a/src/main/java/com/annepolis/lexiconmeum/shared/LexemeSink.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/LexemeSink.java
@@ -2,9 +2,9 @@ package com.annepolis.lexiconmeum.shared;
 
 import java.util.function.Consumer;
 
-public interface LexemeSink extends Consumer<Lexeme<?>> {
+public interface LexemeSink extends Consumer<Lexeme> {
 
-    void accept(Lexeme<?> lexeme);
+    void accept(Lexeme lexeme);
 }
 
 

--- a/src/main/java/com/annepolis/lexiconmeum/shared/LexemeSink.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/LexemeSink.java
@@ -2,9 +2,9 @@ package com.annepolis.lexiconmeum.shared;
 
 import java.util.function.Consumer;
 
-public interface LexemeSink extends Consumer<Lexeme> {
+public interface LexemeSink extends Consumer<Lexeme<?>> {
 
-    void accept(Lexeme lexeme);
+    void accept(Lexeme<?> lexeme);
 }
 
 

--- a/src/main/java/com/annepolis/lexiconmeum/shared/data/load/WiktionaryLexicalDataParser.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/data/load/WiktionaryLexicalDataParser.java
@@ -1,6 +1,5 @@
 package com.annepolis.lexiconmeum.shared.data.load;
 
-import com.annepolis.lexiconmeum.lexeme.detail.Inflection;
 import com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalGender;
 import com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalPosition;
 import com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalTense;
@@ -51,7 +50,7 @@ class WiktionaryLexicalDataParser {
         this.parseMode = parseMode;
     }
 
-    public void parseJsonl(Reader reader, Consumer<Lexeme<? extends Inflection>> consumer) throws IOException {
+    public void parseJsonl(Reader reader, Consumer<Lexeme> consumer) throws IOException {
         BufferedReader br = new BufferedReader(reader);
         String line;
         while ((line = readJsonLine(br)) != null) {
@@ -69,7 +68,7 @@ class WiktionaryLexicalDataParser {
         return br.readLine();
     }
 
-    private Optional<Lexeme<?>> buildLexeme(JsonNode root) {
+    private Optional<Lexeme> buildLexeme(JsonNode root) {
         String lemma = root.path(WORD.get()).asText();
         String posTag = root.path(POSITION.get()).asText();
 
@@ -80,38 +79,41 @@ class WiktionaryLexicalDataParser {
         }
         GrammaticalPosition position = optionalPosition.get();
 
-        switch (position) {
-            case NOUN:
-                Optional<Lexeme<Declension>> declensionLexeme = buildNounLexeme(root, lemma, position);
-                return declensionLexeme.map(lexeme -> (Lexeme<?>) lexeme);
-            case VERB:
-                Optional<Lexeme<Conjugation>> conjugationLexeme = buildVerbLexeme(root, lemma, position);
-                return conjugationLexeme.map(lexeme -> (Lexeme<?>) lexeme);
-            default:
+        return switch (position) {
+            case NOUN -> buildNounLexeme(root, lemma, position);
+            case VERB -> buildVerbLexeme(root, lemma, position);
+            default -> {
                 logger.trace("Unsupported position: {}", position);
-                return Optional.empty();
+                yield Optional.empty();
+            }
+        };
+    }
+
+    private Optional<Lexeme> buildNounLexeme(JsonNode root, String lemma, GrammaticalPosition position) {
+        LexemeBuilder builder = new LexemeBuilder(lemma, position);
+        addSenses(root.path(SENSES.get()), builder);
+        addDeclensionForms(root.path(FORMS.get()), builder);
+        try {
+            return Optional.of(builder.build());
+        } catch (Exception ex) {
+            logger.warn("Failed to build lexeme: {}", ex.getMessage());
+            return Optional.empty();
         }
     }
 
-    private Optional<Lexeme<Declension>> buildNounLexeme(JsonNode root, String lemma, GrammaticalPosition position) {
-        LexemeBuilder<Declension> builder = new LexemeBuilder<>(lemma, position);
-        addSenses(root.path(SENSES.get()), builder);
-        addDeclensionForms(root.path(FORMS.get()), builder);
-
-        return new SafeBuilder<>("LexemeBuilder", builder::build)
-                .build(logger, getParseMode());
-    }
-
-    private Optional<Lexeme<Conjugation>> buildVerbLexeme(JsonNode root, String lemma, GrammaticalPosition position) {
-        LexemeBuilder<Conjugation> builder = new LexemeBuilder<>(lemma, position);
+    private Optional<Lexeme> buildVerbLexeme(JsonNode root, String lemma, GrammaticalPosition position) {
+        LexemeBuilder builder = new LexemeBuilder(lemma, position);
         addSenses(root.path(SENSES.get()), builder);
         addConjugationForms(root.path(FORMS.get()), builder);
-
-        return new SafeBuilder<>("LexemeBuilder", builder::build)
-                .build(logger, getParseMode());
+        try {
+            return Optional.of(builder.build());
+        } catch (Exception ex) {
+            logger.warn("Failed to build lexeme: {}", ex.getMessage());
+            return Optional.empty();
+        }
     }
 
-    private void addDeclensionForms(JsonNode formsNode, LexemeBuilder<Declension> lexemeBuilder) {
+    private void addDeclensionForms(JsonNode formsNode, LexemeBuilder lexemeBuilder) {
         for (JsonNode formNode : formsNode) {
             if (isDeclensionForm(formNode)) {
                 buildDeclension(formNode, getParseMode()).ifPresent(lexemeBuilder::addInflection);
@@ -148,7 +150,7 @@ class WiktionaryLexicalDataParser {
         return Optional.empty();
     }
 
-    private <T extends Inflection> void addSenses(JsonNode sensesNode, LexemeBuilder<T> lexemeBuilder) {
+    private void addSenses(JsonNode sensesNode, LexemeBuilder lexemeBuilder) {
         if (sensesNode.isArray()) {
             for (JsonNode senseNode : sensesNode) {
                 lexemeBuilder.addSense(buildSense(senseNode));
@@ -179,7 +181,7 @@ class WiktionaryLexicalDataParser {
 
         return new SafeBuilder<>("Declension", builder::build).build(logger, mode);
     }
-    private void addConjugationForms(JsonNode formsNode, LexemeBuilder<Conjugation> lexemeBuilder) {
+    private void addConjugationForms(JsonNode formsNode, LexemeBuilder lexemeBuilder) {
         for (JsonNode formNode : formsNode) {
             if (isConjugationForm(formNode)) {
                 try {

--- a/src/main/java/com/annepolis/lexiconmeum/shared/exception/LexemeTypeMismatchException.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/exception/LexemeTypeMismatchException.java
@@ -1,0 +1,7 @@
+package com.annepolis.lexiconmeum.shared.exception;
+
+public class LexemeTypeMismatchException extends RuntimeException {
+    public LexemeTypeMismatchException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/annepolis/lexiconmeum/textsearch/TextSearchServiceConfig.java
+++ b/src/main/java/com/annepolis/lexiconmeum/textsearch/TextSearchServiceConfig.java
@@ -17,8 +17,9 @@ class TextSearchServiceConfig {
     public TextSearchService<String> textSearchService(TextSearchTrieIndexService textSearchTrieIndexService){
         return textSearchTrieIndexService;
     }
+    @SuppressWarnings("java:S1452")
     @Bean
-public Consumer<Lexeme> wordConsumer(TextSearchTrieIndexService textSearchTrieIndexService){
+    public Consumer<Lexeme<?>> wordConsumer(TextSearchTrieIndexService textSearchTrieIndexService){
         return textSearchTrieIndexService;
     }
 

--- a/src/main/java/com/annepolis/lexiconmeum/textsearch/TextSearchServiceConfig.java
+++ b/src/main/java/com/annepolis/lexiconmeum/textsearch/TextSearchServiceConfig.java
@@ -19,7 +19,7 @@ class TextSearchServiceConfig {
     }
     @SuppressWarnings("java:S1452")
     @Bean
-    public Consumer<Lexeme<?>> wordConsumer(TextSearchTrieIndexService textSearchTrieIndexService){
+    public Consumer<Lexeme> wordConsumer(TextSearchTrieIndexService textSearchTrieIndexService){
         return textSearchTrieIndexService;
     }
 

--- a/src/main/java/com/annepolis/lexiconmeum/textsearch/TextSearchSuggestionService.java
+++ b/src/main/java/com/annepolis/lexiconmeum/textsearch/TextSearchSuggestionService.java
@@ -1,6 +1,5 @@
 package com.annepolis.lexiconmeum.textsearch;
 
-import com.annepolis.lexiconmeum.shared.Lexeme;
 import com.annepolis.lexiconmeum.shared.LexemeProvider;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -37,12 +36,12 @@ public class TextSearchSuggestionService implements TextSearchService<TextSearch
     List<TextSearchSuggestionDTO> enrichRawWords(List<String> rawWords) {
         return rawWords.stream()
                 .map(rawWord -> {
-
                     UUID lexemeId = extractLexemeId(rawWord);
                     String word = extractForm(rawWord);
-                    Optional<Lexeme> maybeLexeme = lexemeProvider.getLexemeIfPresent(lexemeId);
-                    return maybeLexeme.map(lexeme -> textSearchSuggestionMapper.toTextSearchDTO(word, lexemeId, lexeme.getPosition()));
-
+                    return lexemeProvider.getLexemeIfPresent(lexemeId)
+                            .map(lexeme ->
+                                textSearchSuggestionMapper.toTextSearchDTO(word, lexemeId, lexeme.getPosition())
+                            );
                 })
                 .flatMap(Optional::stream)
                 .toList();

--- a/src/main/java/com/annepolis/lexiconmeum/textsearch/TextSearchTrieIndexService.java
+++ b/src/main/java/com/annepolis/lexiconmeum/textsearch/TextSearchTrieIndexService.java
@@ -29,15 +29,15 @@ class TextSearchTrieIndexService implements TextSearchService<String>, LexemeSin
         return cache.get("_" + suffix, k -> suffixTextSearchIndex.search(suffix, limit));
     }
 
-    public void populateIndex(Lexeme<? extends Inflection> lexeme) {
-        for(Inflection<?> inflection: lexeme.getInflections()){
+    public void populateIndex(Lexeme lexeme) {
+        for(Inflection inflection: lexeme.getInflections()){
             prefixTextSearchIndex.insert(inflection.getForm(), lexeme.getId());
             suffixTextSearchIndex.insert(new StringBuilder(inflection.getForm()).reverse().toString(), lexeme.getId());
         }
     }
 
     @Override
-    public void accept(Lexeme<?> lexeme) {
+    public void accept(Lexeme lexeme) {
         populateIndex(lexeme);
     }
 

--- a/src/main/java/com/annepolis/lexiconmeum/textsearch/TextSearchTrieIndexService.java
+++ b/src/main/java/com/annepolis/lexiconmeum/textsearch/TextSearchTrieIndexService.java
@@ -19,23 +19,25 @@ class TextSearchTrieIndexService implements TextSearchService<String>, LexemeSin
         this.cache = cache;
     }
 
+    @Override
     public List<String> getWordsStartingWith(String prefix, int limit) {
         return cache.get(prefix, k -> prefixTextSearchIndex.search(prefix, limit));
     }
 
+    @Override
     public List<String> getWordsEndingWith(String suffix, int limit) {
         return cache.get("_" + suffix, k -> suffixTextSearchIndex.search(suffix, limit));
     }
 
-    public void populateIndex(Lexeme lexeme) {
-        for(Inflection inflection: lexeme.getInflections()){
+    public void populateIndex(Lexeme<? extends Inflection> lexeme) {
+        for(Inflection<?> inflection: lexeme.getInflections()){
             prefixTextSearchIndex.insert(inflection.getForm(), lexeme.getId());
             suffixTextSearchIndex.insert(new StringBuilder(inflection.getForm()).reverse().toString(), lexeme.getId());
         }
     }
 
     @Override
-    public void accept(Lexeme lexeme) {
+    public void accept(Lexeme<?> lexeme) {
         populateIndex(lexeme);
     }
 

--- a/src/main/java/com/annepolis/lexiconmeum/web/LexemeDetailController.java
+++ b/src/main/java/com/annepolis/lexiconmeum/web/LexemeDetailController.java
@@ -2,7 +2,7 @@ package com.annepolis.lexiconmeum.web;
 
 import com.annepolis.lexiconmeum.lexeme.detail.noun.DeclensionTableDTO;
 import com.annepolis.lexiconmeum.lexeme.detail.noun.LexemeDeclensionService;
-import com.annepolis.lexiconmeum.lexeme.detail.verb.ConjugationGroupDTO;
+import com.annepolis.lexiconmeum.lexeme.detail.verb.LexemeConjugationDetailDTO;
 import com.annepolis.lexiconmeum.lexeme.detail.verb.LexemeConjugationService;
 import com.annepolis.lexiconmeum.shared.util.JsonDTOLogger;
 import org.apache.logging.log4j.LogManager;
@@ -43,11 +43,11 @@ public class LexemeDetailController {
 
 
     @GetMapping(CONJUGATION)
-    public ConjugationGroupDTO getConjugations(@RequestParam String lexemeId){
+    public LexemeConjugationDetailDTO getConjugations(@RequestParam String lexemeId){
         logger.debug("fetching lexeme: {}", lexemeId);
-        ConjugationGroupDTO tables = lexemeConjugationService.getLexemeDetail(UUID.fromString(lexemeId));
-        jsonDTOLogger.logAsJson(tables);
-        return tables;
+        LexemeConjugationDetailDTO lexemeConjugationDetailDTO = lexemeConjugationService.getLexemeDetail(UUID.fromString(lexemeId));
+        jsonDTOLogger.logAsJson(lexemeConjugationDetailDTO);
+        return lexemeConjugationDetailDTO;
     }
 
 }

--- a/src/test/java/com/annepolis/lexiconmeum/TestUtil.java
+++ b/src/test/java/com/annepolis/lexiconmeum/TestUtil.java
@@ -5,6 +5,7 @@ import com.annepolis.lexiconmeum.lexeme.detail.noun.Declension;
 import com.annepolis.lexiconmeum.lexeme.detail.verb.Conjugation;
 import com.annepolis.lexiconmeum.shared.Lexeme;
 import com.annepolis.lexiconmeum.shared.LexemeBuilder;
+import com.annepolis.lexiconmeum.shared.Sense;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,6 +16,7 @@ import static com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalNumber.
 import static com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalNumber.SINGULAR;
 import static com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalPerson.*;
 import static com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalPosition.VERB;
+import static com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalTense.PERFECT;
 import static com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalTense.PRESENT;
 import static com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalVoice.ACTIVE;
 import static com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalVoice.PASSIVE;
@@ -30,9 +32,8 @@ public class TestUtil {
         lexBuilder.addInflection(getNewTestDeclension( SINGULAR, ACCUSATIVE, "amīcum"));
         lexBuilder.addInflection(getNewTestDeclension( SINGULAR, VOCATIVE, "amīce"));
         lexBuilder.addInflection(getNewTestDeclension( SINGULAR, GENITIVE, "amīcī"));
-        lexBuilder.addInflection(getNewTestDeclension( SINGULAR, ABLATIVE, "amīce"));
-        lexBuilder.addInflection(getNewTestDeclension( SINGULAR, DATIVE, "amīce"));
-        lexBuilder.addInflection(getNewTestDeclension( SINGULAR, VOCATIVE, "amīce"));
+        lexBuilder.addInflection(getNewTestDeclension( SINGULAR, ABLATIVE, "amīcō"));
+        lexBuilder.addInflection(getNewTestDeclension( SINGULAR, DATIVE, "amīcō"));
 
         lexBuilder.addInflection(getNewTestDeclension( PLURAL, NOMINATIVE, "amīcī"));
         lexBuilder.addInflection(getNewTestDeclension( PLURAL, ACCUSATIVE, "amīcōs"));
@@ -45,8 +46,10 @@ public class TestUtil {
 
     }
 
+
+
     private static Declension getNewTestDeclension(GrammaticalNumber number, GrammaticalCase gramCase, String form) {
-        return new Declension.Builder( form).setGrammaticalCase(gramCase).setNumber(number).build();
+        return new Declension.Builder(form).setGrammaticalCase(gramCase).setNumber(number).build();
     }
     public static Lexeme getNewTestVerbLexeme(){
         LexemeBuilder builder = new LexemeBuilder("amo", VERB);
@@ -84,8 +87,19 @@ public class TestUtil {
         buildConjugation(builder, "amēmini", PASSIVE, SUBJUNCTIVE, SECOND, PRESENT, PLURAL);
         buildConjugation(builder, "amentur", PASSIVE, SUBJUNCTIVE, THIRD, PRESENT, PLURAL);
 
-        builder.addInflection(conjugationBuilder.build());
+        buildConjugation(builder, "amāvī", ACTIVE, INDICATIVE, FIRST, PERFECT, SINGULAR);
+        buildConjugation(builder, "amāvīsti", ACTIVE, INDICATIVE, SECOND, PERFECT, SINGULAR);
+        buildConjugation(builder, "amāvit", ACTIVE, INDICATIVE, THIRD, PERFECT, SINGULAR);
+        buildConjugation(builder, "amāvīmus", ACTIVE, INDICATIVE, FIRST, PERFECT, PLURAL);
+        buildConjugation(builder, "amāvītis", ACTIVE, INDICATIVE, SECOND, PERFECT, PLURAL);
+        buildConjugation(builder, "amāverunt", ACTIVE, INDICATIVE, THIRD, PERFECT, PLURAL);
 
+        buildConjugation(builder, "amātus", PASSIVE, INDICATIVE, FIRST, PERFECT, SINGULAR);
+
+
+
+        builder.addInflection(conjugationBuilder.build());
+        builder.addSense(getNewTestSense());
         return builder.build();
 
     }
@@ -96,6 +110,12 @@ public class TestUtil {
             Conjugation.Builder conjugationBuilder = new Conjugation.Builder(form);
             conjugationBuilder.setVoice(voice).setMood(mood).setPerson(person).setTense(tense).setNumber(number);
             builder.addInflection(conjugationBuilder.build());
+    }
+
+    private static Sense getNewTestSense(){
+        Sense.Builder builder = new Sense.Builder();
+        builder.addGloss("to love");
+        return builder.build();
     }
 
     public static List<Lexeme> getMixedPositionTestLexemes(){

--- a/src/test/java/com/annepolis/lexiconmeum/TestUtil.java
+++ b/src/test/java/com/annepolis/lexiconmeum/TestUtil.java
@@ -23,26 +23,26 @@ import static com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalVoice.P
 
 public class TestUtil {
 
-    public static Lexeme getNewTestNounLexeme(){
+    public static Lexeme<Declension> getNewTestNounLexeme(){
 
-        LexemeBuilder lexBuilder = new LexemeBuilder("amīcus", GrammaticalPosition.NOUN);
+        return new LexemeBuilder<Declension>("amīcus", GrammaticalPosition.NOUN)
 
 
-        lexBuilder.addInflection(getNewTestDeclension( SINGULAR, NOMINATIVE,  "amīcus"));
-        lexBuilder.addInflection(getNewTestDeclension( SINGULAR, ACCUSATIVE, "amīcum"));
-        lexBuilder.addInflection(getNewTestDeclension( SINGULAR, VOCATIVE, "amīce"));
-        lexBuilder.addInflection(getNewTestDeclension( SINGULAR, GENITIVE, "amīcī"));
-        lexBuilder.addInflection(getNewTestDeclension( SINGULAR, ABLATIVE, "amīcō"));
-        lexBuilder.addInflection(getNewTestDeclension( SINGULAR, DATIVE, "amīcō"));
+        .addInflection(getNewTestDeclension( SINGULAR, NOMINATIVE,  "amīcus"))
+        .addInflection(getNewTestDeclension( SINGULAR, ACCUSATIVE, "amīcum"))
+        .addInflection(getNewTestDeclension( SINGULAR, VOCATIVE, "amīce"))
+        .addInflection(getNewTestDeclension( SINGULAR, GENITIVE, "amīcī"))
+        .addInflection(getNewTestDeclension( SINGULAR, ABLATIVE, "amīcō"))
+        .addInflection(getNewTestDeclension( SINGULAR, DATIVE, "amīcō"))
 
-        lexBuilder.addInflection(getNewTestDeclension( PLURAL, NOMINATIVE, "amīcī"));
-        lexBuilder.addInflection(getNewTestDeclension( PLURAL, ACCUSATIVE, "amīcōs"));
-        lexBuilder.addInflection(getNewTestDeclension( PLURAL, VOCATIVE,  "amīcī"));
-        lexBuilder.addInflection(getNewTestDeclension( PLURAL, GENITIVE,  "amīcōrum"));
-        lexBuilder.addInflection(getNewTestDeclension( PLURAL, ABLATIVE, "amīcīs"));
-        lexBuilder.addInflection(getNewTestDeclension( PLURAL, DATIVE, "amīcīs"));
+        .addInflection(getNewTestDeclension( PLURAL, NOMINATIVE, "amīcī"))
+        .addInflection(getNewTestDeclension( PLURAL, ACCUSATIVE, "amīcōs"))
+        .addInflection(getNewTestDeclension( PLURAL, VOCATIVE,  "amīcī"))
+        .addInflection(getNewTestDeclension( PLURAL, GENITIVE,  "amīcōrum"))
+        .addInflection(getNewTestDeclension( PLURAL, ABLATIVE, "amīcīs"))
+        .addInflection(getNewTestDeclension( PLURAL, DATIVE, "amīcīs"))
 
-        return lexBuilder.setGender(GrammaticalGender.MASCULINE).build();
+         .setGender(GrammaticalGender.MASCULINE).build();
 
     }
 
@@ -51,13 +51,9 @@ public class TestUtil {
     private static Declension getNewTestDeclension(GrammaticalNumber number, GrammaticalCase gramCase, String form) {
         return new Declension.Builder(form).setGrammaticalCase(gramCase).setNumber(number).build();
     }
-    public static Lexeme getNewTestVerbLexeme(){
-        LexemeBuilder builder = new LexemeBuilder("amo", VERB);
+    public static Lexeme<Conjugation> getNewTestVerbLexeme(){
 
-        Conjugation.Builder conjugationBuilder = new Conjugation.Builder("amāre");
-        conjugationBuilder.setVoice(ACTIVE).setMood(INFINITIVE).setTense(PRESENT);
-        builder.addInflection(conjugationBuilder.build());
-
+        LexemeBuilder<Conjugation> builder = new LexemeBuilder<>("amo", VERB);
 
         buildConjugation(builder, "amō", ACTIVE, INDICATIVE, FIRST, PRESENT, SINGULAR);
         buildConjugation(builder, "amās", ACTIVE, INDICATIVE, SECOND, PRESENT, SINGULAR);
@@ -96,30 +92,32 @@ public class TestUtil {
 
         buildConjugation(builder, "amātus", PASSIVE, INDICATIVE, FIRST, PERFECT, SINGULAR);
 
+        Conjugation conjugation = new Conjugation.Builder("amāre")
+                .setVoice(ACTIVE).setMood(INFINITIVE).setTense(PRESENT).build();
 
-
-        builder.addInflection(conjugationBuilder.build());
-        builder.addSense(getNewTestSense());
-        return builder.build();
+        return  builder.addInflection(conjugation)
+                .addSense(getNewTestSense())
+                .build();
 
     }
 
-    private static void buildConjugation(LexemeBuilder builder, String form, GrammaticalVoice voice, GrammaticalMood mood,
+    private static void buildConjugation(LexemeBuilder<Conjugation> lexemeBuilder, String form, GrammaticalVoice voice, GrammaticalMood mood,
                                   GrammaticalPerson person, GrammaticalTense tense, GrammaticalNumber number){
 
-            Conjugation.Builder conjugationBuilder = new Conjugation.Builder(form);
-            conjugationBuilder.setVoice(voice).setMood(mood).setPerson(person).setTense(tense).setNumber(number);
-            builder.addInflection(conjugationBuilder.build());
+            Conjugation conjugation = new Conjugation.Builder(form)
+            .setVoice(voice).setMood(mood).setPerson(person).setTense(tense).setNumber(number).build();
+
+            lexemeBuilder.addInflection(conjugation);
     }
 
     private static Sense getNewTestSense(){
-        Sense.Builder builder = new Sense.Builder();
-        builder.addGloss("to love");
-        return builder.build();
+        return new Sense.Builder()
+        .addGloss("to love")
+        .build();
     }
 
-    public static List<Lexeme> getMixedPositionTestLexemes(){
-        List<Lexeme> lexemes = new ArrayList<>();
+    public static List<Lexeme<?>> getMixedPositionTestLexemes(){
+        List<Lexeme<?>> lexemes = new ArrayList<>();
 
         lexemes.add(getNewTestVerbLexeme());
         lexemes.add(getNewTestNounLexeme());

--- a/src/test/java/com/annepolis/lexiconmeum/TestUtil.java
+++ b/src/test/java/com/annepolis/lexiconmeum/TestUtil.java
@@ -23,9 +23,9 @@ import static com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalVoice.P
 
 public class TestUtil {
 
-    public static Lexeme<Declension> getNewTestNounLexeme(){
+    public static Lexeme getNewTestNounLexeme(){
 
-        return new LexemeBuilder<Declension>("amīcus", GrammaticalPosition.NOUN)
+        return new LexemeBuilder("amīcus", GrammaticalPosition.NOUN)
 
 
         .addInflection(getNewTestDeclension( SINGULAR, NOMINATIVE,  "amīcus"))
@@ -51,9 +51,9 @@ public class TestUtil {
     private static Declension getNewTestDeclension(GrammaticalNumber number, GrammaticalCase gramCase, String form) {
         return new Declension.Builder(form).setGrammaticalCase(gramCase).setNumber(number).build();
     }
-    public static Lexeme<Conjugation> getNewTestVerbLexeme(){
+    public static Lexeme getNewTestVerbLexeme(){
 
-        LexemeBuilder<Conjugation> builder = new LexemeBuilder<>("amo", VERB);
+        LexemeBuilder builder = new LexemeBuilder("amo", VERB);
 
         buildConjugation(builder, "amō", ACTIVE, INDICATIVE, FIRST, PRESENT, SINGULAR);
         buildConjugation(builder, "amās", ACTIVE, INDICATIVE, SECOND, PRESENT, SINGULAR);
@@ -101,7 +101,7 @@ public class TestUtil {
 
     }
 
-    private static void buildConjugation(LexemeBuilder<Conjugation> lexemeBuilder, String form, GrammaticalVoice voice, GrammaticalMood mood,
+    private static void buildConjugation(LexemeBuilder lexemeBuilder, String form, GrammaticalVoice voice, GrammaticalMood mood,
                                   GrammaticalPerson person, GrammaticalTense tense, GrammaticalNumber number){
 
             Conjugation conjugation = new Conjugation.Builder(form)
@@ -116,8 +116,8 @@ public class TestUtil {
         .build();
     }
 
-    public static List<Lexeme<?>> getMixedPositionTestLexemes(){
-        List<Lexeme<?>> lexemes = new ArrayList<>();
+    public static List<Lexeme> getMixedPositionTestLexemes(){
+        List<Lexeme> lexemes = new ArrayList<>();
 
         lexemes.add(getNewTestVerbLexeme());
         lexemes.add(getNewTestNounLexeme());

--- a/src/test/java/com/annepolis/lexiconmeum/lexeme/detail/noun/LexemeDeclensionDetailServiceTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/lexeme/detail/noun/LexemeDeclensionDetailServiceTest.java
@@ -1,31 +1,46 @@
 package com.annepolis.lexiconmeum.lexeme.detail.noun;
 
 import com.annepolis.lexiconmeum.TestUtil;
+import com.annepolis.lexiconmeum.lexeme.detail.Inflection;
 import com.annepolis.lexiconmeum.shared.Lexeme;
 import com.annepolis.lexiconmeum.shared.LexemeProvider;
+import com.annepolis.lexiconmeum.shared.exception.LexemeTypeMismatchException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 import java.util.UUID;
 
+import static com.annepolis.lexiconmeum.TestUtil.getNewTestNounLexeme;
+
 class LexemeDeclensionDetailServiceTest {
 
     @Test
     void getLexemeDetailGivenLexemeReturnsDeclensionMap(){
         LexemeProvider lexemeProviderStub = new LexemeProvider() {
+
             @Override
-            public Lexeme getLexeme(UUID lemma) {
-                return TestUtil.getNewTestNounLexeme();
+            public Optional<Lexeme<?>> getLexemeIfPresent(UUID lemmaId) {
+
+                return Optional.empty();
             }
 
             @Override
-            public Optional<Lexeme> getLexemeIfPresent(UUID lemmaId) {
-                return Optional.empty();
+            public <T extends Inflection> Lexeme<T> getLexemeOfType(UUID lemmaId, Class<T> expectedType) {
+
+                Lexeme lexeme = TestUtil.getNewTestNounLexeme();
+                boolean matches = lexeme.getInflections().stream().allMatch(expectedType::isInstance);
+                if (!matches) {
+                    throw new LexemeTypeMismatchException("Expected lexeme of type " + expectedType.getSimpleName());
+                }
+
+                @SuppressWarnings("unchecked")
+                Lexeme<T> typedLexeme = (Lexeme<T>) lexeme;
+                return typedLexeme;
             }
         };
         LexemeDeclensionService service = new LexemeDeclensionService(lexemeProviderStub, new LexemeDeclensionMapper());
-        UUID lexemeId = TestUtil.getNewTestNounLexeme().getId();
+        UUID lexemeId = getNewTestNounLexeme().getId();
         DeclensionTableDTO dto = service.getLexemeDetail(lexemeId);
         Assertions.assertNotNull(dto.getTable());
     }

--- a/src/test/java/com/annepolis/lexiconmeum/lexeme/detail/noun/LexemeDeclensionDetailServiceTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/lexeme/detail/noun/LexemeDeclensionDetailServiceTest.java
@@ -20,23 +20,20 @@ class LexemeDeclensionDetailServiceTest {
         LexemeProvider lexemeProviderStub = new LexemeProvider() {
 
             @Override
-            public Optional<Lexeme<?>> getLexemeIfPresent(UUID lemmaId) {
+            public Optional<Lexeme> getLexemeIfPresent(UUID lemmaId) {
 
                 return Optional.empty();
             }
 
             @Override
-            public <T extends Inflection> Lexeme<T> getLexemeOfType(UUID lemmaId, Class<T> expectedType) {
+            public <T extends Inflection> Lexeme getLexemeOfType(UUID lemmaId, Class<T> expectedType) {
 
                 Lexeme lexeme = TestUtil.getNewTestNounLexeme();
                 boolean matches = lexeme.getInflections().stream().allMatch(expectedType::isInstance);
                 if (!matches) {
                     throw new LexemeTypeMismatchException("Expected lexeme of type " + expectedType.getSimpleName());
                 }
-
-                @SuppressWarnings("unchecked")
-                Lexeme<T> typedLexeme = (Lexeme<T>) lexeme;
-                return typedLexeme;
+                return lexeme;
             }
         };
         LexemeDeclensionService service = new LexemeDeclensionService(lexemeProviderStub, new LexemeDeclensionMapper());

--- a/src/test/java/com/annepolis/lexiconmeum/lexeme/detail/verb/InflectionKeyTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/lexeme/detail/verb/InflectionKeyTest.java
@@ -12,14 +12,16 @@ class InflectionKeyTest {
 
     @Test
     void buildsValidInflectionKeyFromConjugation(){
-        Lexeme<Conjugation> lexeme = TestUtil.getNewTestVerbLexeme();
+        Lexeme lexeme = TestUtil.getNewTestVerbLexeme();
         String key = lexeme.getInflections().stream()
-                .filter(c ->
-                        GrammaticalPerson.FIRST == c.getPerson() &&
-                        GrammaticalTense.PRESENT == c.getTense() &&
-                        GrammaticalVoice.ACTIVE == c.getVoice() &&
-                        GrammaticalMood.INDICATIVE == c.getMood() &&
-                        GrammaticalNumber.SINGULAR == c.getNumber())
+                .filter(Conjugation.class::isInstance)
+                .map(i -> (Conjugation) i)
+                .filter(i ->
+                        GrammaticalPerson.FIRST == i.getPerson() &&
+                        GrammaticalTense.PRESENT == i.getTense() &&
+                        GrammaticalVoice.ACTIVE == i.getVoice() &&
+                        GrammaticalMood.INDICATIVE == i.getMood() &&
+                        GrammaticalNumber.SINGULAR == i.getNumber())
                 .findFirst()
                 .map(InflectionKey::of)
                 .orElse(null);

--- a/src/test/java/com/annepolis/lexiconmeum/lexeme/detail/verb/InflectionKeyTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/lexeme/detail/verb/InflectionKeyTest.java
@@ -1,0 +1,53 @@
+package com.annepolis.lexiconmeum.lexeme.detail.verb;
+
+import com.annepolis.lexiconmeum.TestUtil;
+import com.annepolis.lexiconmeum.lexeme.detail.grammar.*;
+import com.annepolis.lexiconmeum.shared.Lexeme;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class InflectionKeyTest {
+
+    @Test
+    void buildsValidInflectionKeyFromConjugation(){
+        InflectionKey underTest = new InflectionKey();
+        Lexeme lexeme = TestUtil.getNewTestVerbLexeme();
+        String key = lexeme.getInflections().stream()
+                .filter(i -> i instanceof Conjugation c &&
+                        GrammaticalPerson.FIRST == c.getPerson() &&
+                        GrammaticalTense.PRESENT == c.getTense() &&
+                        GrammaticalVoice.ACTIVE == c.getVoice() &&
+                        GrammaticalMood.INDICATIVE == c.getMood() &&
+                        GrammaticalNumber.SINGULAR == c.getNumber())
+                .map(i -> (Conjugation) i)
+                .findFirst()
+                .map(c -> underTest.of(c))
+                .orElse(null);
+        Assertions.assertNotNull( key);
+        assertEquals("ACTIVE|INDICATIVE|PRESENT|FIRST|SINGULAR", key);
+
+    }
+
+    @Test
+    void buildsValidFirstPrinciplePartKey(){
+        InflectionKey builder = new InflectionKey();
+        String key = builder.buildFirstPrincipalPartKey();
+        assertEquals("ACTIVE|INDICATIVE|PRESENT|FIRST|SINGULAR", key);
+    }
+
+    @Test
+    void buildsValidSecondPrinciplePartKey(){
+        InflectionKey builder = new InflectionKey();
+        String key = builder.buildSecondPrincipalPartKey();
+        assertEquals("ACTIVE|INFINITIVE|PRESENT", key);
+    }
+
+    @Test
+    void buildsValidThirdPrinciplePartKey(){
+        InflectionKey builder = new InflectionKey();
+        String key = builder.buildThirdPrincipalPartKey();
+        assertEquals("ACTIVE|INDICATIVE|PERFECT|FIRST|SINGULAR", key);
+    }
+}

--- a/src/test/java/com/annepolis/lexiconmeum/lexeme/detail/verb/InflectionKeyTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/lexeme/detail/verb/InflectionKeyTest.java
@@ -12,18 +12,16 @@ class InflectionKeyTest {
 
     @Test
     void buildsValidInflectionKeyFromConjugation(){
-        InflectionKey underTest = new InflectionKey();
-        Lexeme lexeme = TestUtil.getNewTestVerbLexeme();
+        Lexeme<Conjugation> lexeme = TestUtil.getNewTestVerbLexeme();
         String key = lexeme.getInflections().stream()
-                .filter(i -> i instanceof Conjugation c &&
+                .filter(c ->
                         GrammaticalPerson.FIRST == c.getPerson() &&
                         GrammaticalTense.PRESENT == c.getTense() &&
                         GrammaticalVoice.ACTIVE == c.getVoice() &&
                         GrammaticalMood.INDICATIVE == c.getMood() &&
                         GrammaticalNumber.SINGULAR == c.getNumber())
-                .map(i -> (Conjugation) i)
                 .findFirst()
-                .map(c -> underTest.of(c))
+                .map(InflectionKey::of)
                 .orElse(null);
         Assertions.assertNotNull( key);
         assertEquals("ACTIVE|INDICATIVE|PRESENT|FIRST|SINGULAR", key);

--- a/src/test/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationDetailMapperTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/lexeme/detail/verb/LexemeConjugationDetailMapperTest.java
@@ -1,0 +1,26 @@
+package com.annepolis.lexiconmeum.lexeme.detail.verb;
+
+import com.annepolis.lexiconmeum.TestUtil;
+import com.annepolis.lexiconmeum.lexeme.detail.InflectionTableDTO;
+import com.annepolis.lexiconmeum.lexeme.detail.LexemeInflectionMapper;
+import com.annepolis.lexiconmeum.shared.Lexeme;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LexemeConjugationDetailMapperTest {
+
+    @Test
+    void allPrinciplePartsAreMapped(){
+        Lexeme lexeme = TestUtil.getNewTestVerbLexeme();
+        LexemeInflectionMapper mapperStub = new LexemeInflectionMapper() {
+            @Override
+            public InflectionTableDTO toInflectionTableDTO(Lexeme lexeme) {
+                return null;
+            }
+        };
+        LexemeConjugationDetailMapper underTest = new LexemeConjugationDetailMapper(mapperStub, new InflectionKey());
+        LexemeConjugationDetailDTO dto = underTest.toLexemeDetailDTO(lexeme);
+        assertEquals(3,dto.getPrincipleParts().size());
+    }
+}

--- a/src/test/java/com/annepolis/lexiconmeum/shared/data/load/WiktionaryLexicalDataParserTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/shared/data/load/WiktionaryLexicalDataParserTest.java
@@ -35,17 +35,17 @@ class WiktionaryLexicalDataParserTest {
     @Autowired
     private WiktionaryLexicalDataParser parser;
 
-    private List<Lexeme<Conjugation>> verbLexemes;
-    private List<Lexeme<Declension>> nounLexemes;
+    private List<Lexeme> verbLexemes;
+    private List<Lexeme> nounLexemes;
 
-    public List<Lexeme<Conjugation>> getVerbLexemes() throws IOException {
+    public List<Lexeme> getVerbLexemes() throws IOException {
         if(verbLexemes == null) {
             parseVerbLexemes();
         }
         return verbLexemes;
     }
 
-    public List<Lexeme<Declension>> getNounLexemes() throws IOException {
+    public List<Lexeme> getNounLexemes() throws IOException {
         if(nounLexemes == null) {
             parseNounLexemes();
         }
@@ -137,7 +137,7 @@ class WiktionaryLexicalDataParserTest {
 
     @Test
     void InflectionsWithDuplicateTagsAreSetAsAlternativeForms() throws IOException {
-        Optional<Conjugation> maybeConjugation = getVerbLexemes().get(0).getInflections().stream()
+        Optional<Inflection> maybeConjugation = getVerbLexemes().get(0).getInflections().stream()
                 .filter(g -> "amārō".equals(g.getAlternativeForm()))
                 .findFirst();
         assertTrue(maybeConjugation.isPresent());
@@ -161,9 +161,7 @@ class WiktionaryLexicalDataParserTest {
             nounLexemes = new ArrayList<>();
             parser.parseJsonl(reader, lexeme -> {
                 if (lexeme.getInflections().get(0) instanceof Declension) {
-                    @SuppressWarnings("unchecked")
-                    Lexeme<Declension> declined = (Lexeme<Declension>) lexeme;
-                    nounLexemes.add(declined);
+                    nounLexemes.add(lexeme);
                 }
             });
         }
@@ -175,9 +173,7 @@ class WiktionaryLexicalDataParserTest {
             verbLexemes = new ArrayList<>();
             parser.parseJsonl(reader, lexeme -> {
                 if (lexeme.getInflections().get(0) instanceof Conjugation) {
-                    @SuppressWarnings("unchecked")
-                    Lexeme<Conjugation> conjugated = (Lexeme<Conjugation>) lexeme;
-                    verbLexemes.add(conjugated);
+                    verbLexemes.add(lexeme);
                 }
             });
 

--- a/src/test/java/com/annepolis/lexiconmeum/textsearch/TextSearchServiceSpringTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/textsearch/TextSearchServiceSpringTest.java
@@ -30,8 +30,8 @@ class TextSearchServiceSpringTest {
         List<TextSearchSuggestionDTO> result = underTest.getWordsStartingWith("am", 10);
         assertEquals(10, result.size());
 
-        result = underTest.getWordsStartingWith("amara", 10);
-        assertEquals(6, result.size());
+        result = underTest.getWordsStartingWith("amarem", 10);
+        assertEquals(4, result.size());
 
     }
 

--- a/src/test/java/com/annepolis/lexiconmeum/textsearch/TextSearchServiceTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/textsearch/TextSearchServiceTest.java
@@ -43,12 +43,12 @@ class TextSearchServiceTest {
         return  new LexemeProvider() {
 
             @Override
-            public Optional<Lexeme<?>> getLexemeIfPresent(UUID lemmaId) {
+            public Optional<Lexeme> getLexemeIfPresent(UUID lemmaId) {
                 return Optional.empty();
             }
 
             @Override
-            public <T extends Inflection> Lexeme<T> getLexemeOfType(UUID lemmaId, Class<T> expectedType) {
+            public <T extends Inflection> Lexeme getLexemeOfType(UUID lemmaId, Class<T> expectedType) {
 
                 return null;
             }

--- a/src/test/java/com/annepolis/lexiconmeum/textsearch/TextSearchServiceTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/textsearch/TextSearchServiceTest.java
@@ -1,6 +1,6 @@
 package com.annepolis.lexiconmeum.textsearch;
 
-import com.annepolis.lexiconmeum.TestUtil;
+import com.annepolis.lexiconmeum.lexeme.detail.Inflection;
 import com.annepolis.lexiconmeum.shared.Lexeme;
 import com.annepolis.lexiconmeum.shared.LexemeProvider;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,14 +41,16 @@ class TextSearchServiceTest {
 
     LexemeProvider getLexemeProvider(){
         return  new LexemeProvider() {
+
             @Override
-            public Lexeme getLexeme(UUID lemma) {
-                return TestUtil.getNewTestVerbLexeme();
+            public Optional<Lexeme<?>> getLexemeIfPresent(UUID lemmaId) {
+                return Optional.empty();
             }
 
             @Override
-            public Optional<Lexeme> getLexemeIfPresent(UUID lemmaId) {
-                return Optional.empty();
+            public <T extends Inflection> Lexeme<T> getLexemeOfType(UUID lemmaId, Class<T> expectedType) {
+
+                return null;
             }
         };
     }

--- a/src/test/java/com/annepolis/lexiconmeum/textsearch/TextSearchTrieIndexTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/textsearch/TextSearchTrieIndexTest.java
@@ -3,8 +3,6 @@ package com.annepolis.lexiconmeum.textsearch;
 import com.annepolis.lexiconmeum.TestUtil;
 import com.annepolis.lexiconmeum.lexeme.detail.Inflection;
 import com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalPosition;
-import com.annepolis.lexiconmeum.lexeme.detail.noun.Declension;
-import com.annepolis.lexiconmeum.lexeme.detail.verb.Conjugation;
 import com.annepolis.lexiconmeum.shared.Lexeme;
 import com.annepolis.lexiconmeum.shared.LexemeBuilder;
 import org.junit.jupiter.api.Test;
@@ -29,10 +27,10 @@ class TextSearchTrieIndexTest {
     void trieReturnsAllMatchingWordsGivenPrefix(){
         String prefix = "test";
         String word = prefix + "word";
-        LexemeBuilder<Declension> dLexemeBuilder = new LexemeBuilder(word, GrammaticalPosition.NOUN);
+        LexemeBuilder dLexemeBuilder = new LexemeBuilder(word, GrammaticalPosition.NOUN);
         Lexeme lexeme = dLexemeBuilder.build();
 
-        LexemeBuilder<Conjugation> cLexemeBuilder = new LexemeBuilder( word, GrammaticalPosition.VERB);
+        LexemeBuilder cLexemeBuilder = new LexemeBuilder( word, GrammaticalPosition.VERB);
         Lexeme lexeme2 = cLexemeBuilder.build();
 
         TextSearchTrieIndex underTest = new TextSearchTrieIndex(new TextSearchSuggestionMapper());
@@ -48,7 +46,7 @@ class TextSearchTrieIndexTest {
     @Test
     void givenPrefixReturnsAllMatches(){
         TextSearchTrieIndex underTest = new TextSearchTrieIndex(new TextSearchSuggestionMapper());
-        Lexeme<?> lexeme = TestUtil.getNewTestNounLexeme();
+        Lexeme lexeme = TestUtil.getNewTestNounLexeme();
         for (Inflection inflection : lexeme.getInflections()){
             underTest.insert(inflection.getForm(), lexeme.getId());
         }
@@ -59,8 +57,8 @@ class TextSearchTrieIndexTest {
     @Test
     void givenSuffixReturnsAllMatches(){
         TextSearchTrieIndex underTest = new TextSearchTrieIndex(new TextSearchSuggestionMapper());
-        List<Lexeme<?>> lexemes = TestUtil.getMixedPositionTestLexemes();
-        for(Lexeme<?> lexeme : lexemes) {
+        List<Lexeme> lexemes = TestUtil.getMixedPositionTestLexemes();
+        for(Lexeme lexeme : lexemes) {
             for (String word : lexeme.getInflections().stream().map( inflection -> new StringBuilder(inflection.getForm()).reverse().toString()).toList()){
                     underTest.insert(word, lexeme.getId());
             }

--- a/src/test/java/com/annepolis/lexiconmeum/textsearch/TextSearchTrieIndexTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/textsearch/TextSearchTrieIndexTest.java
@@ -3,6 +3,8 @@ package com.annepolis.lexiconmeum.textsearch;
 import com.annepolis.lexiconmeum.TestUtil;
 import com.annepolis.lexiconmeum.lexeme.detail.Inflection;
 import com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalPosition;
+import com.annepolis.lexiconmeum.lexeme.detail.noun.Declension;
+import com.annepolis.lexiconmeum.lexeme.detail.verb.Conjugation;
 import com.annepolis.lexiconmeum.shared.Lexeme;
 import com.annepolis.lexiconmeum.shared.LexemeBuilder;
 import org.junit.jupiter.api.Test;
@@ -27,11 +29,11 @@ class TextSearchTrieIndexTest {
     void trieReturnsAllMatchingWordsGivenPrefix(){
         String prefix = "test";
         String word = prefix + "word";
-        LexemeBuilder lexemeBuilder = new LexemeBuilder(word, GrammaticalPosition.NOUN);
-        Lexeme lexeme = lexemeBuilder.build();
+        LexemeBuilder<Declension> dLexemeBuilder = new LexemeBuilder(word, GrammaticalPosition.NOUN);
+        Lexeme lexeme = dLexemeBuilder.build();
 
-        lexemeBuilder = new LexemeBuilder( word, GrammaticalPosition.VERB);
-        Lexeme lexeme2 = lexemeBuilder.build();
+        LexemeBuilder<Conjugation> cLexemeBuilder = new LexemeBuilder( word, GrammaticalPosition.VERB);
+        Lexeme lexeme2 = cLexemeBuilder.build();
 
         TextSearchTrieIndex underTest = new TextSearchTrieIndex(new TextSearchSuggestionMapper());
         underTest.insert(lexeme.getLemma(), lexeme.getId());
@@ -46,7 +48,7 @@ class TextSearchTrieIndexTest {
     @Test
     void givenPrefixReturnsAllMatches(){
         TextSearchTrieIndex underTest = new TextSearchTrieIndex(new TextSearchSuggestionMapper());
-        Lexeme lexeme = TestUtil.getNewTestNounLexeme();
+        Lexeme<?> lexeme = TestUtil.getNewTestNounLexeme();
         for (Inflection inflection : lexeme.getInflections()){
             underTest.insert(inflection.getForm(), lexeme.getId());
         }
@@ -57,8 +59,8 @@ class TextSearchTrieIndexTest {
     @Test
     void givenSuffixReturnsAllMatches(){
         TextSearchTrieIndex underTest = new TextSearchTrieIndex(new TextSearchSuggestionMapper());
-        List<Lexeme> lexemes = TestUtil.getMixedPositionTestLexemes();
-        for(Lexeme lexeme : lexemes) {
+        List<Lexeme<?>> lexemes = TestUtil.getMixedPositionTestLexemes();
+        for(Lexeme<?> lexeme : lexemes) {
             for (String word : lexeme.getInflections().stream().map( inflection -> new StringBuilder(inflection.getForm()).reverse().toString()).toList()){
                     underTest.insert(word, lexeme.getId());
             }

--- a/src/test/java/com/annepolis/lexiconmeum/textsearch/TextSearchTrieIndexTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/textsearch/TextSearchTrieIndexTest.java
@@ -51,7 +51,7 @@ class TextSearchTrieIndexTest {
             underTest.insert(inflection.getForm(), lexeme.getId());
         }
         List<String> results = underTest.search("amico", 20);
-        assertEquals(2, results.size());
+        assertEquals(4, results.size());
     }
 
     @Test
@@ -64,7 +64,7 @@ class TextSearchTrieIndexTest {
             }
         }
         List<String> results = underTest.search(new StringBuilder("is").reverse().toString(), 20);
-        assertEquals(6, results.size());
+        assertEquals(7, results.size());
     }
 
 

--- a/src/test/java/com/annepolis/lexiconmeum/web/LexemeDetailControllerIntegrationTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/web/LexemeDetailControllerIntegrationTest.java
@@ -2,7 +2,6 @@ package com.annepolis.lexiconmeum.web;
 
 import com.annepolis.lexiconmeum.TestUtil;
 import com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalPosition;
-import com.annepolis.lexiconmeum.lexeme.detail.noun.Declension;
 import com.annepolis.lexiconmeum.shared.LexemeBuilder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -49,7 +48,7 @@ class LexemeDetailControllerIntegrationTest {
 
     @Test
     void testDeclensionDetailEndpoint() throws JsonProcessingException {
-        LexemeBuilder<Declension> lexemeBuilder = new LexemeBuilder<>("poculum", GrammaticalPosition.NOUN);
+        LexemeBuilder lexemeBuilder = new LexemeBuilder("poculum", GrammaticalPosition.NOUN);
         UUID lexemeId = lexemeBuilder.build().getId();
         String url = getFullBaseUrl() + DECLENSION + "?lexemeId=" + lexemeId.toString();
         ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);

--- a/src/test/java/com/annepolis/lexiconmeum/web/LexemeDetailControllerIntegrationTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/web/LexemeDetailControllerIntegrationTest.java
@@ -1,6 +1,9 @@
 package com.annepolis.lexiconmeum.web;
 
 import com.annepolis.lexiconmeum.TestUtil;
+import com.annepolis.lexiconmeum.lexeme.detail.grammar.GrammaticalPosition;
+import com.annepolis.lexiconmeum.lexeme.detail.noun.Declension;
+import com.annepolis.lexiconmeum.shared.LexemeBuilder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
@@ -46,9 +49,9 @@ class LexemeDetailControllerIntegrationTest {
 
     @Test
     void testDeclensionDetailEndpoint() throws JsonProcessingException {
-        UUID lexemeId = TestUtil.getNewTestNounLexeme().getId();
+        LexemeBuilder<Declension> lexemeBuilder = new LexemeBuilder<>("poculum", GrammaticalPosition.NOUN);
+        UUID lexemeId = lexemeBuilder.build().getId();
         String url = getFullBaseUrl() + DECLENSION + "?lexemeId=" + lexemeId.toString();
-
         ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
         ObjectMapper objectMapper = new ObjectMapper();
         Object jsonObject = objectMapper.readValue(response.getBody(), Object.class);


### PR DESCRIPTION
Summary
This PR introduces several updates to improve the structure, accuracy, and clarity of the LexemeDetail API and related code.

What's Changed
Added support for principal parts and definitions in the LexemeDetailDTO
Backend parsing logic to extract and expose these new fields in the API response
Refactored

Applied proper Java generics to the Lexeme and Inflection model hierarchy to improve type safety
Replaced raw and wildcard types with specific parameterized types across services and mappers
Simplified

Removed generics from Lexeme<T> after reassessing usage patterns, simplifying the model since runtime casting was still required in most cases

Notes
This is a breaking change to the LexemeDetail response schema, as the root object now includes more than just inflection data
Internal builder and DTO logic has been updated to reflect the new structure