### PR TITLE
Rename and refactor `GrammaticalPosition` to `PartOfSpeech`

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ A staged development plan to balance MVP delivery, engineering quality, and lear
 
 - [ ] Add support for all word types (e.g. adjectives, adverbs, etc.)
     - [x] adjectives
-    - [ ] adverbs
+    - [x] adverbs
     - [ ] prepositions 
 - [ ] Complete verb support (add passive voice and any missing tenses/moods)
 - [ ] Fix dropdown arrow navigation in search field
@@ -23,7 +23,7 @@ A staged development plan to balance MVP delivery, engineering quality, and lear
 
 **Goal:** Match the backend's seamless deploy process to reduce friction and risk.
 
-- [ ] Automate front-end build and deployment (GitHub Actions or local script)
+- [x] Automate front-end build and deployment (GitHub Actions or local script)
 - [ ] Use `rsync` or safe delete strategy to prevent accidental file loss
 - [ ] Version build output for traceability (e.g., `lexiconmeum-frontend-20250725`)
 - [ ] Ensure deploy logs clearly show success/failure
@@ -33,8 +33,8 @@ A staged development plan to balance MVP delivery, engineering quality, and lear
 
 ## 🧪 Phase 1.6 – Front-End Testing
 
-- [ ] Set up Vitest for unit testing
-- [ ] Write tests for suggestion box logic, error handling, etc.
+- [x] Set up Vitest for unit testing
+- [x] Write tests for suggestion box logic, error handling, etc.
 - [ ] Test keyboard navigation behavior in dropdown
 - [ ] Run tests in CI (GitHub Actions or locally)
 

--- a/src/main/java/com/annepolis/lexiconmeum/cache/inmemory/InMemoryLexemeCache.java
+++ b/src/main/java/com/annepolis/lexiconmeum/cache/inmemory/InMemoryLexemeCache.java
@@ -30,7 +30,7 @@ import java.util.UUID;
     public Lexeme getLexemeOfType(UUID lexemeId, GrammaticalPosition expectedType) {
         Lexeme lexeme = lexemeIdToLexemeLookup.get(lexemeId);
 
-        boolean matches = expectedType.equals(lexeme.getGrammaticalPosition());
+        boolean matches = expectedType.equals(lexeme.getPartOfSpeech());
         if (!matches) {
             throw new LexemeTypeMismatchException("Expected lexeme of type " + expectedType.name());
         }

--- a/src/main/java/com/annepolis/lexiconmeum/cache/inmemory/InMemoryLexemeCache.java
+++ b/src/main/java/com/annepolis/lexiconmeum/cache/inmemory/InMemoryLexemeCache.java
@@ -4,7 +4,7 @@ import com.annepolis.lexiconmeum.shared.LexemeReader;
 import com.annepolis.lexiconmeum.shared.LexemeSink;
 import com.annepolis.lexiconmeum.shared.exception.LexemeTypeMismatchException;
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Component;
@@ -27,7 +27,7 @@ import java.util.UUID;
     }
 
     @Override
-    public Lexeme getLexemeOfType(UUID lexemeId, GrammaticalPosition expectedType) {
+    public Lexeme getLexemeOfType(UUID lexemeId, PartOfSpeech expectedType) {
         Lexeme lexeme = lexemeIdToLexemeLookup.get(lexemeId);
 
         boolean matches = expectedType.equals(lexeme.getPartOfSpeech());

--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataJsonKey.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataJsonKey.java
@@ -3,7 +3,7 @@ package com.annepolis.lexiconmeum.ingest.wiktionary;
 public enum WiktionaryLexicalDataJsonKey {
 
     WORD("word"),
-    POSITION("pos"),
+    PART_OF_SPEECH("pos"),
     NOUN("noun"),
     VERB("verb"),
     DECLENSION("declension"),

--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataParser.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataParser.java
@@ -6,6 +6,7 @@ import com.annepolis.lexiconmeum.shared.model.Sense;
 import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalFeature;
 import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalTense;
 import com.annepolis.lexiconmeum.shared.model.grammar.InflectionFeature;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 import com.annepolis.lexiconmeum.shared.model.inflection.Agreement;
 import com.annepolis.lexiconmeum.shared.model.inflection.Conjugation;
 import com.annepolis.lexiconmeum.shared.model.inflection.Declension;
@@ -76,12 +77,12 @@ class WiktionaryLexicalDataParser {
         String posTag = root.path(POSITION.get()).asText();
         String etymologyNumber = normalizeEtymologyNumber(root.path(ETYMOLOGY_NUMBER.get()).asText());
 
-        Optional<GrammaticalPosition> optionalPosition = GrammaticalPosition.resolveWithWarning(posTag, logger);
+        Optional<PartOfSpeech> optionalPosition = PartOfSpeech.resolveWithWarning(posTag, logger);
 
         if (optionalPosition.isEmpty()) {
             return Optional.empty();
         }
-        GrammaticalPosition position = optionalPosition.get();
+        PartOfSpeech position = optionalPosition.get();
 
         LexemeBuilder builder = new LexemeBuilder(lemma, position, etymologyNumber);
 

--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataParser.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataParser.java
@@ -74,27 +74,27 @@ class WiktionaryLexicalDataParser {
 
     private Optional<Lexeme> buildLexeme(JsonNode root) {
         String lemma = root.path(WORD.get()).asText();
-        String posTag = root.path(POSITION.get()).asText();
+        String posTag = root.path(PART_OF_SPEECH.get()).asText();
         String etymologyNumber = normalizeEtymologyNumber(root.path(ETYMOLOGY_NUMBER.get()).asText());
 
-        Optional<PartOfSpeech> optionalPosition = PartOfSpeech.resolveWithWarning(posTag, logger);
+        Optional<PartOfSpeech> optionalPartOfSpeech = PartOfSpeech.resolveWithWarning(posTag, logger);
 
-        if (optionalPosition.isEmpty()) {
+        if (optionalPartOfSpeech.isEmpty()) {
             return Optional.empty();
         }
-        PartOfSpeech position = optionalPosition.get();
+        PartOfSpeech partOfSpeech = optionalPartOfSpeech.get();
 
-        LexemeBuilder builder = new LexemeBuilder(lemma, position, etymologyNumber);
+        LexemeBuilder builder = new LexemeBuilder(lemma, partOfSpeech, etymologyNumber);
 
         addSenses(root.path(SENSES.get()), builder);
 
-        return switch (position) {
+        return switch (partOfSpeech) {
             case NOUN -> buildLexemeWithForms(builder, root, this::addDeclensionForms);
             case VERB -> buildLexemeWithForms(builder, root, this::addConjugationForms);
             case ADJECTIVE -> buildLexemeWithForms(builder, root, this::addAdjectiveForms);
             case ADVERB -> buildLexemeWithOutForms(builder);
             default -> {
-                logger.trace("Unsupported position: {}", position);
+                logger.trace("Unsupported partOfSpeech: {}", partOfSpeech);
                 yield Optional.empty();
             }
         };

--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataParser.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataParser.java
@@ -4,7 +4,6 @@ import com.annepolis.lexiconmeum.shared.model.Lexeme;
 import com.annepolis.lexiconmeum.shared.model.LexemeBuilder;
 import com.annepolis.lexiconmeum.shared.model.Sense;
 import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalFeature;
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
 import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalTense;
 import com.annepolis.lexiconmeum.shared.model.grammar.InflectionFeature;
 import com.annepolis.lexiconmeum.shared.model.inflection.Agreement;

--- a/src/main/java/com/annepolis/lexiconmeum/shared/LexemeReader.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/LexemeReader.java
@@ -1,7 +1,7 @@
 package com.annepolis.lexiconmeum.shared;
 
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -10,6 +10,6 @@ public interface LexemeReader {
 
     @SuppressWarnings("java:S1452")
     Optional<Lexeme> getLexemeIfPresent(UUID lemmaId);
-    Lexeme getLexemeOfType(UUID lemmaId, GrammaticalPosition expectedType);
+    Lexeme getLexemeOfType(UUID lemmaId, PartOfSpeech expectedType);
 
 }

--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/Lexeme.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/Lexeme.java
@@ -8,7 +8,7 @@ import com.annepolis.lexiconmeum.shared.model.inflection.Inflection;
 import java.util.*;
 
 /**
- * Equality and hashCode are based on lemma, position, and etymologyNumber,
+ * Equality and hashCode are based on lemma, partOfSpeech, and etymologyNumber,
  * which together define the identity of a Lexeme. The `id` field is derived
  * from these and not included in equality checks.
  */
@@ -16,7 +16,7 @@ public class Lexeme {
 
     private final UUID id;
     private final String lemma;
-    private final PartOfSpeech position;
+    private final PartOfSpeech partOfSpeech;
     private final PartOfSpeechDetails partOfSpeechDetails;
     private final String etymologyNumber;
     private final Set<InflectionClass> inflectionClasses;
@@ -25,7 +25,7 @@ public class Lexeme {
 
     Lexeme(LexemeBuilder builder) {
         this.lemma = builder.getLemma();
-        this.position = builder.getPosition();
+        this.partOfSpeech = builder.getPartOfSpeech();
         this.etymologyNumber = builder.getEtymologyNumber();
         this.id = builder.getId();
         this.inflections = builder.getInflections();
@@ -41,7 +41,7 @@ public class Lexeme {
     public String getLemma() { return lemma; }
 
     public PartOfSpeech getPartOfSpeech() {
-        return position;
+        return partOfSpeech;
     }
 
     public PartOfSpeechDetails getPartOfSpeechDetails() {
@@ -68,18 +68,18 @@ public class Lexeme {
         if (o == null || getClass() != o.getClass()) return false;
         Lexeme lexeme = (Lexeme) o;
         return Objects.equals(lemma, lexeme.lemma)
-                && Objects.equals(position, lexeme.position)
+                && Objects.equals(partOfSpeech, lexeme.partOfSpeech)
                 && Objects.equals(etymologyNumber, lexeme.etymologyNumber);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(lemma, position, etymologyNumber);
+        return Objects.hash(lemma, partOfSpeech, etymologyNumber);
     }
 
     @Override
     public String toString() {
-        return String.format("Lexeme{id='%s', lemma='%s', position='%s', etymology-number='%s'}", id, lemma, position, etymologyNumber);
+        return String.format("Lexeme{id='%s', lemma='%s', partOfSpeech='%s', etymology-number='%s'}", id, lemma, partOfSpeech, etymologyNumber);
     }
 
 }

--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/Lexeme.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/Lexeme.java
@@ -1,6 +1,5 @@
 package com.annepolis.lexiconmeum.shared.model;
 
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
 import com.annepolis.lexiconmeum.shared.model.grammar.InflectionClass;
 import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeechDetails;
 import com.annepolis.lexiconmeum.shared.model.inflection.Inflection;

--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/Lexeme.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/Lexeme.java
@@ -1,6 +1,7 @@
 package com.annepolis.lexiconmeum.shared.model;
 
 import com.annepolis.lexiconmeum.shared.model.grammar.InflectionClass;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeechDetails;
 import com.annepolis.lexiconmeum.shared.model.inflection.Inflection;
 
@@ -15,7 +16,7 @@ public class Lexeme {
 
     private final UUID id;
     private final String lemma;
-    private final GrammaticalPosition position;
+    private final PartOfSpeech position;
     private final PartOfSpeechDetails partOfSpeechDetails;
     private final String etymologyNumber;
     private final Set<InflectionClass> inflectionClasses;
@@ -39,7 +40,7 @@ public class Lexeme {
 
     public String getLemma() { return lemma; }
 
-    public GrammaticalPosition getGrammaticalPosition() {
+    public PartOfSpeech getPartOfSpeech() {
         return position;
     }
 

--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/LexemeBuilder.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/LexemeBuilder.java
@@ -2,6 +2,7 @@ package com.annepolis.lexiconmeum.shared.model;
 
 import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalGender;
 import com.annepolis.lexiconmeum.shared.model.grammar.InflectionClass;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeechDetails;
 import com.annepolis.lexiconmeum.shared.model.inflection.Inflection;
 import com.annepolis.lexiconmeum.shared.model.inflection.InflectionKey;
@@ -13,7 +14,7 @@ public class LexemeBuilder {
 
     private final UUID id;
     private final String lemma;
-    private final GrammaticalPosition position;
+    private final PartOfSpeech position;
     private final String etymologyNumber;
     private GrammaticalGender gender;
     private PartOfSpeechDetails partOfSpeechDetails;
@@ -21,14 +22,14 @@ public class LexemeBuilder {
     private final Map<String, Inflection> inflectionIndex = new HashMap<>();
     private final Set<InflectionClass> inflectionClasses = new TreeSet<>();
 
-    public LexemeBuilder(String lemma, GrammaticalPosition position, String etymologyNumber){
+    public LexemeBuilder(String lemma, PartOfSpeech position, String etymologyNumber){
         this.lemma = lemma;
         this.position = position;
         this.etymologyNumber = etymologyNumber;
         this.id = computeId( lemma, position, etymologyNumber);
     }
 
-    private static UUID computeId(String lemma, GrammaticalPosition position, String etymologyNumber){
+    private static UUID computeId(String lemma, PartOfSpeech position, String etymologyNumber){
         return UUID.nameUUIDFromBytes(computeId(lemma, position.name(), etymologyNumber).getBytes(StandardCharsets.UTF_8));
     }
 
@@ -44,7 +45,7 @@ public class LexemeBuilder {
         return lemma;
     }
 
-    public GrammaticalPosition getPosition(){
+    public PartOfSpeech getPosition(){
         return this.position;
     }
 
@@ -55,10 +56,6 @@ public class LexemeBuilder {
     public LexemeBuilder setGender(GrammaticalGender gender){
         this.gender = gender;
         return this;
-    }
-
-    public GrammaticalGender getGender() {
-        return gender;
     }
 
     public PartOfSpeechDetails getPartOfSpeechDetails() {

--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/LexemeBuilder.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/LexemeBuilder.java
@@ -1,7 +1,6 @@
 package com.annepolis.lexiconmeum.shared.model;
 
 import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalGender;
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
 import com.annepolis.lexiconmeum.shared.model.grammar.InflectionClass;
 import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeechDetails;
 import com.annepolis.lexiconmeum.shared.model.inflection.Inflection;

--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/LexemeBuilder.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/LexemeBuilder.java
@@ -14,7 +14,7 @@ public class LexemeBuilder {
 
     private final UUID id;
     private final String lemma;
-    private final PartOfSpeech position;
+    private final PartOfSpeech partOfSpeech;
     private final String etymologyNumber;
     private GrammaticalGender gender;
     private PartOfSpeechDetails partOfSpeechDetails;
@@ -22,19 +22,19 @@ public class LexemeBuilder {
     private final Map<String, Inflection> inflectionIndex = new HashMap<>();
     private final Set<InflectionClass> inflectionClasses = new TreeSet<>();
 
-    public LexemeBuilder(String lemma, PartOfSpeech position, String etymologyNumber){
+    public LexemeBuilder(String lemma, PartOfSpeech partOfSpeech, String etymologyNumber){
         this.lemma = lemma;
-        this.position = position;
+        this.partOfSpeech = partOfSpeech;
         this.etymologyNumber = etymologyNumber;
-        this.id = computeId( lemma, position, etymologyNumber);
+        this.id = computeId( lemma, partOfSpeech, etymologyNumber);
     }
 
-    private static UUID computeId(String lemma, PartOfSpeech position, String etymologyNumber){
-        return UUID.nameUUIDFromBytes(computeId(lemma, position.name(), etymologyNumber).getBytes(StandardCharsets.UTF_8));
+    private static UUID computeId(String lemma, PartOfSpeech partOfSpeech, String etymologyNumber){
+        return UUID.nameUUIDFromBytes(computeId(lemma, partOfSpeech.name(), etymologyNumber).getBytes(StandardCharsets.UTF_8));
     }
 
-    private static String computeId(String lemma, String position, String etymologyNumber) {
-        return lemma + "#" + position + "#" + etymologyNumber;
+    private static String computeId(String lemma, String partOfSpeech, String etymologyNumber) {
+        return lemma + "#" + partOfSpeech + "#" + etymologyNumber;
     }
 
     public UUID getId() {
@@ -45,8 +45,8 @@ public class LexemeBuilder {
         return lemma;
     }
 
-    public PartOfSpeech getPosition(){
-        return this.position;
+    public PartOfSpeech getPartOfSpeech(){
+        return this.partOfSpeech;
     }
 
     public String getEtymologyNumber() {
@@ -106,10 +106,10 @@ public class LexemeBuilder {
 
     public Lexeme build(){
 
-        if (lemma == null || position == null) {
+        if (lemma == null || partOfSpeech == null) {
             throw new IllegalStateException("Missing required fields: " +
                     (lemma == null ? "lemma " : "") +
-                    (position == null ? "position " : ""));
+                    (partOfSpeech == null ? "partOfSpeech " : ""));
         }
 
         return new Lexeme(this);

--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/PartOfSpeech.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/PartOfSpeech.java
@@ -30,14 +30,14 @@ public enum PartOfSpeech {
 
     public static PartOfSpeech resolveOrThrow(String tag) {
         return fromTag(tag)
-                .orElseThrow(() -> new IllegalArgumentException("Unknown grammatical position: " + tag));
+                .orElseThrow(() -> new IllegalArgumentException("Unknown partOfSpeech: " + tag));
     }
 
     public static Optional<PartOfSpeech> resolveWithWarning(String tag, Logger logger) {
-        Optional<PartOfSpeech> position = fromTag(tag);
-        if (position.isEmpty()) {
-            logger.trace("Unknown grammatical position tag: '{}'", tag);
+        Optional<PartOfSpeech> partOfSpeech = fromTag(tag);
+        if (partOfSpeech.isEmpty()) {
+            logger.trace("Unknown partOfSpeech tag: '{}'", tag);
         }
-        return position;
+        return partOfSpeech;
     }
 }

--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/PartOfSpeech.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/PartOfSpeech.java
@@ -18,10 +18,6 @@ public enum PartOfSpeech {
         this.inflectionType = inflectionType;
     }
 
-    public String getTag() {
-        return tag;
-    }
-
     public String getInflectionType() {
         return inflectionType;
     }

--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/PartOfSpeech.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/PartOfSpeech.java
@@ -5,7 +5,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.Arrays;
 import java.util.Optional;
 
-public enum GrammaticalPosition {
+public enum PartOfSpeech {
     NOUN("noun", "declension"),
     VERB("verb", "conjugation"),
     ADVERB("adv", ""),
@@ -13,7 +13,7 @@ public enum GrammaticalPosition {
     private final String tag;
     private final String inflectionType;
 
-    GrammaticalPosition(String tag, String inflectionType) {
+    PartOfSpeech(String tag, String inflectionType) {
         this.tag = tag;
         this.inflectionType = inflectionType;
     }
@@ -26,19 +26,19 @@ public enum GrammaticalPosition {
         return inflectionType;
     }
 
-    public static Optional<GrammaticalPosition> fromTag(String tag) {
+    public static Optional<PartOfSpeech> fromTag(String tag) {
         return Arrays.stream(values())
                 .filter(pos -> pos.tag.equalsIgnoreCase(tag))
                 .findFirst();
     }
 
-    public static GrammaticalPosition resolveOrThrow(String tag) {
+    public static PartOfSpeech resolveOrThrow(String tag) {
         return fromTag(tag)
                 .orElseThrow(() -> new IllegalArgumentException("Unknown grammatical position: " + tag));
     }
 
-    public static Optional<GrammaticalPosition> resolveWithWarning(String tag, Logger logger) {
-        Optional<GrammaticalPosition> position = fromTag(tag);
+    public static Optional<PartOfSpeech> resolveWithWarning(String tag, Logger logger) {
+        Optional<PartOfSpeech> position = fromTag(tag);
         if (position.isEmpty()) {
             logger.trace("Unknown grammatical position tag: '{}'", tag);
         }

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/LexemeDetailController.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/LexemeDetailController.java
@@ -4,7 +4,7 @@ import com.annepolis.lexiconmeum.shared.LexemeReader;
 import com.annepolis.lexiconmeum.shared.exception.LexemeNotFoundException;
 import com.annepolis.lexiconmeum.shared.exception.LexemeTypeMismatchException;
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 import com.annepolis.lexiconmeum.shared.util.JsonDTOLogger;
 import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.LexemeDetailResponse;
 import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.LexemeDetailUseCase;
@@ -38,7 +38,7 @@ class LexemeDetailController {
     @GetMapping(LEXEME_DETAIL)
     ResponseEntity<LexemeDetailResponse> getLexemeDetail(
             @PathVariable UUID id,
-            @RequestParam(name = "type", required = false) GrammaticalPosition expectedType
+            @RequestParam(name = "type", required = false) PartOfSpeech expectedType
     ) {
         Lexeme lexeme = getLexeme(id);
 

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/LexemeDetailController.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/LexemeDetailController.java
@@ -42,8 +42,8 @@ class LexemeDetailController {
     ) {
         Lexeme lexeme = getLexeme(id);
 
-        if (expectedType != null && lexeme.getGrammaticalPosition() != expectedType) {
-            throw new LexemeTypeMismatchException("Expected " + expectedType + " but got " + lexeme.getGrammaticalPosition());
+        if (expectedType != null && lexeme.getPartOfSpeech() != expectedType) {
+            throw new LexemeTypeMismatchException("Expected " + expectedType + " but got " + lexeme.getPartOfSpeech());
         }
         LexemeDetailResponse response = lexemeDetailUseCase.execute(lexeme);
         jsonDTOLogger.logAsJson(response);

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/LexemeDetailResponse.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/LexemeDetailResponse.java
@@ -16,7 +16,7 @@ public class LexemeDetailResponse {
 
     String lemma;
     UUID lexemeId;
-    PartOfSpeech position;
+    PartOfSpeech partOfSpeech;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     GrammaticalGender grammaticalGender;
@@ -41,12 +41,12 @@ public class LexemeDetailResponse {
         this.lemma = lemma;
     }
 
-    public PartOfSpeech getPosition() {
-        return position;
+    public PartOfSpeech getPartOfSpeech() {
+        return partOfSpeech;
     }
 
-    public void setPosition(PartOfSpeech position) {
-        this.position = position;
+    public void setPartOfSpeech(PartOfSpeech partOfSpeech) {
+        this.partOfSpeech = partOfSpeech;
     }
 
     public UUID getLexemeId() {

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/LexemeDetailResponse.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/LexemeDetailResponse.java
@@ -1,7 +1,7 @@
 package com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly;
 
 import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalGender;
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.inflection.InflectionTableDTO;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -16,7 +16,7 @@ public class LexemeDetailResponse {
 
     String lemma;
     UUID lexemeId;
-    GrammaticalPosition position;
+    PartOfSpeech position;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     GrammaticalGender grammaticalGender;
@@ -41,11 +41,11 @@ public class LexemeDetailResponse {
         this.lemma = lemma;
     }
 
-    public GrammaticalPosition getPosition() {
+    public PartOfSpeech getPosition() {
         return position;
     }
 
-    public void setPosition(GrammaticalPosition position) {
+    public void setPosition(PartOfSpeech position) {
         this.position = position;
     }
 

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/LexemeDetailResponseAssembler.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/LexemeDetailResponseAssembler.java
@@ -1,15 +1,15 @@
 package com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly;
 
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 
 import java.util.List;
 import java.util.Map;
 
 class LexemeDetailResponseAssembler implements LexemeDetailUseCase {
-    private final Map<GrammaticalPosition, List<LexemeDetailSectionContributor>> pipelines;
+    private final Map<PartOfSpeech, List<LexemeDetailSectionContributor>> pipelines;
 
-    public LexemeDetailResponseAssembler(Map<GrammaticalPosition, List<LexemeDetailSectionContributor>> pipelines) {
+    public LexemeDetailResponseAssembler(Map<PartOfSpeech, List<LexemeDetailSectionContributor>> pipelines) {
         this.pipelines = pipelines;
     }
 

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/LexemeDetailResponseAssembler.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/LexemeDetailResponseAssembler.java
@@ -16,7 +16,7 @@ class LexemeDetailResponseAssembler implements LexemeDetailUseCase {
     @Override
     public LexemeDetailResponse execute(Lexeme lexeme) {
         var dto = new LexemeDetailResponse();
-        var sectionContributors = pipelines.getOrDefault(lexeme.getGrammaticalPosition(), List.of());
+        var sectionContributors = pipelines.getOrDefault(lexeme.getPartOfSpeech(), List.of());
         sectionContributors.forEach(c -> c.contribute(lexeme, dto));
         return dto;
     }

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/LexemeDetailResponseAssemblerConfig.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/LexemeDetailResponseAssemblerConfig.java
@@ -1,6 +1,6 @@
 package com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly;
 
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.inflection.AgreementTableMapper;
 import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.inflection.ConjugationTableMapper;
 import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.inflection.DeclensionTableMapper;
@@ -26,28 +26,28 @@ import java.util.*;
 
            // Add/remove contributors as needed
     ) {
-        Map<GrammaticalPosition, List<LexemeDetailSectionContributor>> pipelines = new EnumMap<>(GrammaticalPosition.class);
+        Map<PartOfSpeech, List<LexemeDetailSectionContributor>> pipelines = new EnumMap<>(PartOfSpeech.class);
 
         var common = List.of(identityContributor, definitionsContributor);
 
-        for (GrammaticalPosition position : GrammaticalPosition.values()) {
+        for (PartOfSpeech position : PartOfSpeech.values()) {
             pipelines.put(position, new ArrayList<>(common));
         }
 
-        pipelines.get(GrammaticalPosition.VERB).addAll(List.of(
+        pipelines.get(PartOfSpeech.VERB).addAll(List.of(
                 inflectionTableContributor,
                 verbPrincipalPartsContributor,
                 inflectionClassContributor
         ));
 
-        pipelines.get(GrammaticalPosition.NOUN).addAll(List.of(
+        pipelines.get(PartOfSpeech.NOUN).addAll(List.of(
                 inflectionTableContributor,
                 nounPrincipalPartsContributor,
                 nounGenderSectionContributor,
                 inflectionClassContributor
         ));
 
-        pipelines.get(GrammaticalPosition.ADJECTIVE).addAll(List.of(
+        pipelines.get(PartOfSpeech.ADJECTIVE).addAll(List.of(
                 inflectionTableContributor,
                 inflectionClassContributor
         ));
@@ -55,24 +55,24 @@ import java.util.*;
     }
 
     @Bean
-    Map<GrammaticalPosition, InflectionTableMapper> inflectionMappers(
+    Map<PartOfSpeech, InflectionTableMapper> inflectionMappers(
             ConjugationTableMapper conjugationTableMapper,
             DeclensionTableMapper lexemeDeclensionMapper,
             AgreementTableMapper lexemeAgreementMapper
     ) {
-        Map<GrammaticalPosition, InflectionTableMapper> mappers = new EnumMap<>(GrammaticalPosition.class);
-        mappers.put(GrammaticalPosition.VERB, conjugationTableMapper);
-        mappers.put(GrammaticalPosition.NOUN, lexemeDeclensionMapper);
-        mappers.put(GrammaticalPosition.ADJECTIVE, lexemeAgreementMapper);
+        Map<PartOfSpeech, InflectionTableMapper> mappers = new EnumMap<>(PartOfSpeech.class);
+        mappers.put(PartOfSpeech.VERB, conjugationTableMapper);
+        mappers.put(PartOfSpeech.NOUN, lexemeDeclensionMapper);
+        mappers.put(PartOfSpeech.ADJECTIVE, lexemeAgreementMapper);
         return mappers;
     }
 
     @Bean
-    Set<GrammaticalPosition> inflectionClassPositions() {
+    Set<PartOfSpeech> inflectionClassPositions() {
         return EnumSet.of(
-                GrammaticalPosition.VERB,
-                GrammaticalPosition.NOUN,
-                GrammaticalPosition.ADJECTIVE
+                PartOfSpeech.VERB,
+                PartOfSpeech.NOUN,
+                PartOfSpeech.ADJECTIVE
         );
     }
 

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/LexemeDetailResponseAssemblerConfig.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/LexemeDetailResponseAssemblerConfig.java
@@ -30,8 +30,8 @@ import java.util.*;
 
         var common = List.of(identityContributor, definitionsContributor);
 
-        for (PartOfSpeech position : PartOfSpeech.values()) {
-            pipelines.put(position, new ArrayList<>(common));
+        for (PartOfSpeech partOfSpeech : PartOfSpeech.values()) {
+            pipelines.put(partOfSpeech, new ArrayList<>(common));
         }
 
         pipelines.get(PartOfSpeech.VERB).addAll(List.of(
@@ -68,7 +68,7 @@ import java.util.*;
     }
 
     @Bean
-    Set<PartOfSpeech> inflectionClassPositions() {
+    Set<PartOfSpeech> inflectionClassPartOfSpeechs() {
         return EnumSet.of(
                 PartOfSpeech.VERB,
                 PartOfSpeech.NOUN,

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/IdentitySectionContributor.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/IdentitySectionContributor.java
@@ -13,7 +13,7 @@ class IdentitySectionContributor implements LexemeDetailSectionContributor {
     @Override
     public void contribute(Lexeme lexeme, LexemeDetailResponse dto) {
         dto.setLexemeId(lexeme.getId());
-        dto.setPosition(lexeme.getPartOfSpeech());
+        dto.setPartOfSpeech(lexeme.getPartOfSpeech());
         dto.setLemma(lexeme.getLemma());
     }
 }

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/IdentitySectionContributor.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/IdentitySectionContributor.java
@@ -13,7 +13,7 @@ class IdentitySectionContributor implements LexemeDetailSectionContributor {
     @Override
     public void contribute(Lexeme lexeme, LexemeDetailResponse dto) {
         dto.setLexemeId(lexeme.getId());
-        dto.setPosition(lexeme.getGrammaticalPosition());
+        dto.setPosition(lexeme.getPartOfSpeech());
         dto.setLemma(lexeme.getLemma());
     }
 }

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/InflectionClassSectionContributor.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/InflectionClassSectionContributor.java
@@ -12,15 +12,15 @@ import java.util.stream.Collectors;
 
 @Component("inflectionClassSectionContributor")
 class InflectionClassSectionContributor implements LexemeDetailSectionContributor {
-    private final Set<PartOfSpeech> positions;
+    private final Set<PartOfSpeech> partsOfSpeech;
 
-    public InflectionClassSectionContributor(Set<PartOfSpeech> positions) {
-        this.positions = positions;
+    public InflectionClassSectionContributor(Set<PartOfSpeech> partsOfSpeech) {
+        this.partsOfSpeech = partsOfSpeech;
     }
 
     @Override
     public boolean supports(Lexeme lexeme) {
-        return positions.contains(lexeme.getPartOfSpeech());
+        return partsOfSpeech.contains(lexeme.getPartOfSpeech());
     }
 
     @Override

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/InflectionClassSectionContributor.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/InflectionClassSectionContributor.java
@@ -1,7 +1,6 @@
 package com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.section;
 
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
 import com.annepolis.lexiconmeum.shared.model.grammar.InflectionClass;
 import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.LexemeDetailResponse;
 import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.LexemeDetailSectionContributor;
@@ -20,7 +19,7 @@ class InflectionClassSectionContributor implements LexemeDetailSectionContributo
 
     @Override
     public boolean supports(Lexeme lexeme) {
-        return positions.contains(lexeme.getGrammaticalPosition());
+        return positions.contains(lexeme.getPartOfSpeech());
     }
 
     @Override
@@ -29,7 +28,7 @@ class InflectionClassSectionContributor implements LexemeDetailSectionContributo
                 .map(InflectionClass::getDisplayTag)
                 .collect(Collectors.joining(" & "));
         if (!display.isBlank()) {
-            String suffix = lexeme.getGrammaticalPosition().getInflectionType();
+            String suffix = lexeme.getPartOfSpeech().getInflectionType();
             dto.setInflectionClass(display + " " + suffix);
         }
     }

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/InflectionClassSectionContributor.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/InflectionClassSectionContributor.java
@@ -2,6 +2,7 @@ package com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.section;
 
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
 import com.annepolis.lexiconmeum.shared.model.grammar.InflectionClass;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.LexemeDetailResponse;
 import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.LexemeDetailSectionContributor;
 import org.springframework.stereotype.Component;
@@ -11,9 +12,9 @@ import java.util.stream.Collectors;
 
 @Component("inflectionClassSectionContributor")
 class InflectionClassSectionContributor implements LexemeDetailSectionContributor {
-    private final Set<GrammaticalPosition> positions;
+    private final Set<PartOfSpeech> positions;
 
-    public InflectionClassSectionContributor(Set<GrammaticalPosition> positions) {
+    public InflectionClassSectionContributor(Set<PartOfSpeech> positions) {
         this.positions = positions;
     }
 

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/InflectionTableSectionContributor.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/InflectionTableSectionContributor.java
@@ -19,12 +19,12 @@ class InflectionTableSectionContributor implements LexemeDetailSectionContributo
 
     @Override
     public boolean supports(Lexeme lexeme) {
-        return mappers.containsKey(lexeme.getGrammaticalPosition());
+        return mappers.containsKey(lexeme.getPartOfSpeech());
     }
 
     @Override
     public void contribute(Lexeme lexeme, LexemeDetailResponse dto) {
-        dto.setInflectionTableDTO(mappers.get(lexeme.getGrammaticalPosition()).toInflectionTableDTO(lexeme));
+        dto.setInflectionTableDTO(mappers.get(lexeme.getPartOfSpeech()).toInflectionTableDTO(lexeme));
     }
 
 }

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/InflectionTableSectionContributor.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/InflectionTableSectionContributor.java
@@ -1,7 +1,7 @@
 package com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.section;
 
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.LexemeDetailResponse;
 import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.LexemeDetailSectionContributor;
 import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.inflection.InflectionTableMapper;
@@ -11,9 +11,9 @@ import java.util.Map;
 
 @Component("inflectionTableSectionContributor")
 class InflectionTableSectionContributor implements LexemeDetailSectionContributor {
-    private final Map<GrammaticalPosition, InflectionTableMapper> mappers;
+    private final Map<PartOfSpeech, InflectionTableMapper> mappers;
 
-    public InflectionTableSectionContributor(Map<GrammaticalPosition, InflectionTableMapper> mappers) {
+    public InflectionTableSectionContributor(Map<PartOfSpeech, InflectionTableMapper> mappers) {
         this.mappers = mappers;
     }
 

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/NounGenderSectionContributor.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/NounGenderSectionContributor.java
@@ -1,7 +1,6 @@
 package com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.section;
 
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
 import com.annepolis.lexiconmeum.shared.model.grammar.NounDetails;
 import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.LexemeDetailResponse;
 import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.LexemeDetailSectionContributor;

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/NounGenderSectionContributor.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/NounGenderSectionContributor.java
@@ -2,6 +2,7 @@ package com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.section;
 
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
 import com.annepolis.lexiconmeum.shared.model.grammar.NounDetails;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.LexemeDetailResponse;
 import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.LexemeDetailSectionContributor;
 import org.springframework.stereotype.Component;
@@ -11,7 +12,7 @@ class NounGenderSectionContributor implements LexemeDetailSectionContributor {
 
     @Override
     public boolean supports(Lexeme lexeme) {
-        return lexeme.getGrammaticalPosition() == GrammaticalPosition.NOUN;
+        return lexeme.getPartOfSpeech() == PartOfSpeech.NOUN;
     }
 
     @Override

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/NounPrincipalPartsSectionContributor.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/NounPrincipalPartsSectionContributor.java
@@ -1,7 +1,7 @@
 package com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.section;
 
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 import com.annepolis.lexiconmeum.shared.model.inflection.Inflection;
 import com.annepolis.lexiconmeum.shared.model.inflection.InflectionKey;
 import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.LexemeDetailResponse;
@@ -22,7 +22,7 @@ class NounPrincipalPartsSectionContributor implements LexemeDetailSectionContrib
 
     @Override
     public boolean supports(Lexeme lexeme) {
-        return lexeme.getGrammaticalPosition() == GrammaticalPosition.NOUN;
+        return lexeme.getPartOfSpeech() == PartOfSpeech.NOUN;
     }
 
     @Override

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/VerbPrincipalPartsSectionContributor.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/VerbPrincipalPartsSectionContributor.java
@@ -1,7 +1,7 @@
 package com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.section;
 
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 import com.annepolis.lexiconmeum.shared.model.inflection.Inflection;
 import com.annepolis.lexiconmeum.shared.model.inflection.InflectionKey;
 import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.LexemeDetailResponse;
@@ -21,7 +21,7 @@ class VerbPrincipalPartsSectionContributor implements LexemeDetailSectionContrib
 
     @Override
     public boolean supports(Lexeme lexeme) {
-        return lexeme.getGrammaticalPosition() == GrammaticalPosition.VERB;
+        return lexeme.getPartOfSpeech() == PartOfSpeech.VERB;
     }
 
 

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/app/AutocompleteService.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/app/AutocompleteService.java
@@ -44,7 +44,7 @@ public class AutocompleteService implements AutocompleteUseCase {
                 .filter(match -> match != null && match.form() != null && !match.form().isBlank() && match.lexemeId() != null)
                 .map(match -> lexemeReader.getLexemeIfPresent(match.lexemeId())
                         .map(lexeme ->
-                                suggestionMapper.toResponse(match.form(), match.lexemeId(), lexeme.getGrammaticalPosition())
+                                suggestionMapper.toResponse(match.form(), match.lexemeId(), lexeme.getPartOfSpeech())
                         ))
                 .flatMap(Optional::stream)
                 .toList();

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/app/SuggestionMapper.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/app/SuggestionMapper.java
@@ -1,6 +1,6 @@
 package com.annepolis.lexiconmeum.webapi.bff.textsearch.app;
 
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
@@ -8,7 +8,7 @@ import java.util.UUID;
 @Component
 public class SuggestionMapper {
 
-    SuggestionResponse toResponse(String word, UUID lexemeId, GrammaticalPosition grammaticalPosition){
-        return new SuggestionResponse(word, lexemeId, grammaticalPosition);
+    SuggestionResponse toResponse(String word, UUID lexemeId, PartOfSpeech partOfSpeech){
+        return new SuggestionResponse(word, lexemeId, partOfSpeech);
     }
 }

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/app/SuggestionResponse.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/app/SuggestionResponse.java
@@ -1,6 +1,6 @@
 package com.annepolis.lexiconmeum.webapi.bff.textsearch.app;
 
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 
 import java.util.UUID;
 
@@ -8,12 +8,12 @@ public class SuggestionResponse {
 
     private String word;
     private UUID lexemeId;
-    private GrammaticalPosition grammaticalPosition;
+    private final PartOfSpeech partOfSpeech;
 
-    public SuggestionResponse(String word, UUID lexemeId, GrammaticalPosition grammaticalPosition){
+    public SuggestionResponse(String word, UUID lexemeId, PartOfSpeech partOfSpeech){
         this.word = word;
         this.lexemeId = lexemeId;
-        this.grammaticalPosition = grammaticalPosition;
+        this.partOfSpeech = partOfSpeech;
     }
     public String getWord() { return word;}
 
@@ -29,7 +29,7 @@ public class SuggestionResponse {
         this.lexemeId = lexemeId;
     }
 
-    public GrammaticalPosition getGrammaticalPosition() {
-        return grammaticalPosition;
+    public PartOfSpeech getPartOfSpeech() {
+        return partOfSpeech;
     }
 }

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/domain/DelegatingSearchableFormsExtractor.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/domain/DelegatingSearchableFormsExtractor.java
@@ -19,12 +19,12 @@ public class DelegatingSearchableFormsExtractor implements SearchableFormsExtrac
     @Override
     public Set<String> getSearchableForms(Lexeme lexeme) {
         Objects.requireNonNull(lexeme, "lexeme must not be null");
-        PartOfSpeech position =
+        PartOfSpeech partOfSpeech =
                 Objects.requireNonNull(lexeme.getPartOfSpeech(), "lexeme.partOfSpeech must not be null");
 
-        SearchableFormsExtractor delegate = formsProviders.get(position);
+        SearchableFormsExtractor delegate = formsProviders.get(partOfSpeech);
         if (delegate == null) {
-            throw new IllegalStateException("No SearchableFormsExtractor configured for position: " + position);
+            throw new IllegalStateException("No SearchableFormsExtractor configured for partOfSpeech: " + partOfSpeech);
         }
 
         return formsProviders.get(lexeme.getPartOfSpeech()).getSearchableForms(lexeme);

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/domain/DelegatingSearchableFormsExtractor.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/domain/DelegatingSearchableFormsExtractor.java
@@ -1,7 +1,7 @@
 package com.annepolis.lexiconmeum.webapi.bff.textsearch.domain;
 
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 
 import java.util.Map;
 import java.util.Objects;
@@ -9,9 +9,9 @@ import java.util.Set;
 
 public class DelegatingSearchableFormsExtractor implements SearchableFormsExtractor {
 
-    Map<GrammaticalPosition, SearchableFormsExtractor> formsProviders;
+    Map<PartOfSpeech, SearchableFormsExtractor> formsProviders;
 
-    public DelegatingSearchableFormsExtractor(Map<GrammaticalPosition, SearchableFormsExtractor> formsProviders) {
+    public DelegatingSearchableFormsExtractor(Map<PartOfSpeech, SearchableFormsExtractor> formsProviders) {
         this.formsProviders = Map.copyOf(formsProviders);
     }
 
@@ -19,8 +19,8 @@ public class DelegatingSearchableFormsExtractor implements SearchableFormsExtrac
     @Override
     public Set<String> getSearchableForms(Lexeme lexeme) {
         Objects.requireNonNull(lexeme, "lexeme must not be null");
-        GrammaticalPosition position =
-                Objects.requireNonNull(lexeme.getGrammaticalPosition(), "lexeme.grammaticalPosition must not be null");
+        PartOfSpeech position =
+                Objects.requireNonNull(lexeme.getPartOfSpeech(), "lexeme.partOfSpeech must not be null");
 
         SearchableFormsExtractor delegate = formsProviders.get(position);
         if (delegate == null) {

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/domain/DelegatingSearchableFormsExtractor.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/domain/DelegatingSearchableFormsExtractor.java
@@ -27,6 +27,6 @@ public class DelegatingSearchableFormsExtractor implements SearchableFormsExtrac
             throw new IllegalStateException("No SearchableFormsExtractor configured for position: " + position);
         }
 
-        return formsProviders.get(lexeme.getGrammaticalPosition()).getSearchableForms(lexeme);
+        return formsProviders.get(lexeme.getPartOfSpeech()).getSearchableForms(lexeme);
     }
 }

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/domain/DelegatingSearchableFormsExtractorConfig.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/domain/DelegatingSearchableFormsExtractorConfig.java
@@ -27,7 +27,7 @@ public class DelegatingSearchableFormsExtractorConfig {
 
         if (!missing.isEmpty()) {
             throw new IllegalStateException(
-                    "No SearchableFormsExtractor configured for positions: " + missing);
+                    "No SearchableFormsExtractor configured for partsOfSpeech: " + missing);
         }
 
         return new DelegatingSearchableFormsExtractor(formsExtractors);

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/domain/DelegatingSearchableFormsExtractorConfig.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/domain/DelegatingSearchableFormsExtractorConfig.java
@@ -1,6 +1,6 @@
 package com.annepolis.lexiconmeum.webapi.bff.textsearch.domain;
 
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -16,13 +16,13 @@ public class DelegatingSearchableFormsExtractorConfig {
             SearchableInflectedFormsExtractor inflectedFormsProvider,
             SearchableUninflectedFormsExtractor uninflectedFormsProvider
     ){
-        Map<GrammaticalPosition, SearchableFormsExtractor> formsExtractors = new EnumMap<>(GrammaticalPosition.class);
-        formsExtractors.put(GrammaticalPosition.VERB, inflectedFormsProvider);
-        formsExtractors.put(GrammaticalPosition.NOUN, inflectedFormsProvider);
-        formsExtractors.put(GrammaticalPosition.ADJECTIVE, inflectedFormsProvider);
-        formsExtractors.put(GrammaticalPosition.ADVERB, uninflectedFormsProvider);
+        Map<PartOfSpeech, SearchableFormsExtractor> formsExtractors = new EnumMap<>(PartOfSpeech.class);
+        formsExtractors.put(PartOfSpeech.VERB, inflectedFormsProvider);
+        formsExtractors.put(PartOfSpeech.NOUN, inflectedFormsProvider);
+        formsExtractors.put(PartOfSpeech.ADJECTIVE, inflectedFormsProvider);
+        formsExtractors.put(PartOfSpeech.ADVERB, uninflectedFormsProvider);
 
-        Set<GrammaticalPosition> missing = EnumSet.allOf(GrammaticalPosition.class);
+        Set<PartOfSpeech> missing = EnumSet.allOf(PartOfSpeech.class);
         missing.removeAll(formsExtractors.keySet());
 
         if (!missing.isEmpty()) {

--- a/src/test/java/com/annepolis/lexiconmeum/TestUtil.java
+++ b/src/test/java/com/annepolis/lexiconmeum/TestUtil.java
@@ -119,7 +119,7 @@ public class TestUtil {
         .build();
     }
 
-    public static List<Lexeme> getMixedPositionTestLexemes(){
+    public static List<Lexeme> getMixedPartOfSpeechTestLexemes(){
         List<Lexeme> lexemes = new ArrayList<>();
 
         lexemes.add(getNewTestVerbLexeme());

--- a/src/test/java/com/annepolis/lexiconmeum/TestUtil.java
+++ b/src/test/java/com/annepolis/lexiconmeum/TestUtil.java
@@ -22,12 +22,13 @@ import static com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalTense.PE
 import static com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalTense.PRESENT;
 import static com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalVoice.ACTIVE;
 import static com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalVoice.PASSIVE;
+import static com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech.VERB;
 
 public class TestUtil {
 
     public static Lexeme getNewTestNounLexeme(){
 
-        return new LexemeBuilder("amīcus", GrammaticalPosition.NOUN, "1")
+        return new LexemeBuilder("amīcus", PartOfSpeech.NOUN, "1")
 
 
         .addInflection(getNewTestDeclension( SINGULAR, NOMINATIVE,  "amīcus"))
@@ -214,7 +215,7 @@ public class TestUtil {
     }
 
     public static Lexeme getNewTestAdjectiveLexeme(){
-        LexemeBuilder builder = new LexemeBuilder("pulcher", GrammaticalPosition.ADJECTIVE, "1");
+        LexemeBuilder builder = new LexemeBuilder("pulcher", PartOfSpeech.ADJECTIVE, "1");
         builder.addInflectionClass(InflectionClass.FIRST);
         builder.addInflectionClass(InflectionClass.SECOND);
         for(Agreement agreement : generateAgreements()){
@@ -224,7 +225,7 @@ public class TestUtil {
     }
 
     public static Lexeme getNewTestThreeTerminationAdjectiveLexeme(){
-        LexemeBuilder builder = new LexemeBuilder("celer", GrammaticalPosition.ADJECTIVE, "1");
+        LexemeBuilder builder = new LexemeBuilder("celer", PartOfSpeech.ADJECTIVE, "1");
         builder.addInflectionClass(InflectionClass.THIRD);
         builder.setPartOfSpeechDetails(new AdjectiveDetails(AdjectiveTerminationType.THREE_TERMINATION));
         for(Agreement agreement : generateAgreements()){

--- a/src/test/java/com/annepolis/lexiconmeum/TestUtil.java
+++ b/src/test/java/com/annepolis/lexiconmeum/TestUtil.java
@@ -18,7 +18,6 @@ import static com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalMood.*;
 import static com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalNumber.PLURAL;
 import static com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalNumber.SINGULAR;
 import static com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPerson.*;
-import static com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition.VERB;
 import static com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalTense.PERFECT;
 import static com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalTense.PRESENT;
 import static com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalVoice.ACTIVE;

--- a/src/test/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataParserTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataParserTest.java
@@ -2,7 +2,6 @@ package com.annepolis.lexiconmeum.ingest.wiktionary;
 
 import com.annepolis.lexiconmeum.TestUtil;
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
 import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalTense;
 import com.annepolis.lexiconmeum.shared.model.inflection.*;
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataParserTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataParserTest.java
@@ -3,6 +3,7 @@ package com.annepolis.lexiconmeum.ingest.wiktionary;
 import com.annepolis.lexiconmeum.TestUtil;
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
 import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalTense;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 import com.annepolis.lexiconmeum.shared.model.inflection.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -94,9 +95,9 @@ class WiktionaryLexicalDataParserTest {
             List<Lexeme> lexemes = new ArrayList<>();
             parser.parseJsonl(reader, lexemes::add);
 
-            assertEquals(9, lexemes.size());
-            assertEquals(GrammaticalPosition.VERB, lexemes.get(0).getGrammaticalPosition());
-            assertEquals(GrammaticalPosition.NOUN, lexemes.get(1).getGrammaticalPosition());
+            assertEquals(10, lexemes.size());
+            assertEquals(PartOfSpeech.VERB, lexemes.get(0).getPartOfSpeech());
+            assertEquals(PartOfSpeech.NOUN, lexemes.get(1).getPartOfSpeech());
         }
     }
 

--- a/src/test/java/com/annepolis/lexiconmeum/shared/model/LexemeTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/shared/model/LexemeTest.java
@@ -8,7 +8,7 @@ class LexemeTest {
     void equalsContract() {
         EqualsVerifier.forClass(Lexeme.class)
                 .usingGetClass()
-                .withIgnoredFields("id", "inflectionClasses", "senses", "inflections")
+                .withIgnoredFields("id", "inflectionClasses", "senses", "inflections", "partOfSpeechDetails")
                 .verify();
     }
 }

--- a/src/test/java/com/annepolis/lexiconmeum/utils/TestLexemeFactory.java
+++ b/src/test/java/com/annepolis/lexiconmeum/utils/TestLexemeFactory.java
@@ -25,7 +25,7 @@ public final class TestLexemeFactory {
 
         AdjectiveDetails details = new AdjectiveDetails( terminationType);
 
-        LexemeBuilder lexemeBuilder = new LexemeBuilder("test-adj", GrammaticalPosition.ADJECTIVE, "1" );
+        LexemeBuilder lexemeBuilder = new LexemeBuilder("test-adj", PartOfSpeech.ADJECTIVE, "1" );
         lexemeBuilder.setPartOfSpeechDetails(details);
 
         for (Agreement a : agreements) {

--- a/src/test/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/LexemeDetailControllerIntegrationTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/LexemeDetailControllerIntegrationTest.java
@@ -2,7 +2,7 @@ package com.annepolis.lexiconmeum.webapi.bff.lexemedetail;
 
 import com.annepolis.lexiconmeum.TestUtil;
 import com.annepolis.lexiconmeum.shared.model.LexemeBuilder;
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 import com.annepolis.lexiconmeum.webapi.ApiRoutes;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -48,7 +48,7 @@ class LexemeDetailControllerIntegrationTest {
 
     @Test
     void testLexemeEndpoint() throws JsonProcessingException {
-        LexemeBuilder lexemeBuilder = new LexemeBuilder("amo", GrammaticalPosition.VERB, "1");
+        LexemeBuilder lexemeBuilder = new LexemeBuilder("amo", PartOfSpeech.VERB, "1");
         UUID lexemeId = lexemeBuilder.build().getId();
 
         String url = UriComponentsBuilder
@@ -68,7 +68,7 @@ class LexemeDetailControllerIntegrationTest {
 
     @Test
     void testDetailEndpoint() throws JsonProcessingException {
-        LexemeBuilder lexemeBuilder = new LexemeBuilder("poculum", GrammaticalPosition.NOUN, "1");
+        LexemeBuilder lexemeBuilder = new LexemeBuilder("poculum", PartOfSpeech.NOUN, "1");
         UUID lexemeId = lexemeBuilder.build().getId();
 
         String url = UriComponentsBuilder
@@ -87,7 +87,7 @@ class LexemeDetailControllerIntegrationTest {
     }
     @Test
     void testDetailEndpointWitAdjectiveId() throws JsonProcessingException {
-        LexemeBuilder lexemeBuilder = new LexemeBuilder("celer", GrammaticalPosition.ADJECTIVE, "1");
+        LexemeBuilder lexemeBuilder = new LexemeBuilder("celer", PartOfSpeech.ADJECTIVE, "1");
         UUID lexemeId = lexemeBuilder.build().getId();
 
         String url = UriComponentsBuilder
@@ -128,7 +128,7 @@ class LexemeDetailControllerIntegrationTest {
 
     @Test
     void testTypeMismatchReturnsConflict() {
-        LexemeBuilder lexemeBuilder = new LexemeBuilder("poculum", GrammaticalPosition.NOUN, "1");
+        LexemeBuilder lexemeBuilder = new LexemeBuilder("poculum", PartOfSpeech.NOUN, "1");
         UUID lexemeId = lexemeBuilder.build().getId();
 
         String url = UriComponentsBuilder

--- a/src/test/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/app/AutocompleteServiceTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/app/AutocompleteServiceTest.java
@@ -2,7 +2,7 @@ package com.annepolis.lexiconmeum.webapi.bff.textsearch.app;
 
 import com.annepolis.lexiconmeum.shared.LexemeReader;
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 import com.annepolis.lexiconmeum.webapi.bff.textsearch.domain.FormMatch;
 import com.annepolis.lexiconmeum.webapi.bff.textsearch.index.AutocompleteIndex;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,7 +46,7 @@ class AutocompleteServiceTest {
                 return Optional.empty();
             }
             @Override
-            public Lexeme getLexemeOfType(UUID lemmaId, GrammaticalPosition expectedType) {
+            public Lexeme getLexemeOfType(UUID lemmaId, PartOfSpeech expectedType) {
                 return null;
             }
         };

--- a/src/test/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/index/TrieAutocompleteIndexTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/index/TrieAutocompleteIndexTest.java
@@ -61,7 +61,7 @@ class TrieAutocompleteIndexTest {
     @Test
     void givenSuffixReturnsAllUniqueMatches(){
         TrieAutocompleteIndex underTest = new TrieAutocompleteIndex();
-        List<Lexeme> lexemes = TestUtil.getMixedPositionTestLexemes();
+        List<Lexeme> lexemes = TestUtil.getMixedPartOfSpeechTestLexemes();
 
 
         for(Lexeme lexeme : lexemes) {

--- a/src/test/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/index/TrieAutocompleteIndexTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/index/TrieAutocompleteIndexTest.java
@@ -3,7 +3,7 @@ package com.annepolis.lexiconmeum.webapi.bff.textsearch.index;
 import com.annepolis.lexiconmeum.TestUtil;
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
 import com.annepolis.lexiconmeum.shared.model.LexemeBuilder;
-import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalPosition;
+import com.annepolis.lexiconmeum.shared.model.grammar.PartOfSpeech;
 import com.annepolis.lexiconmeum.shared.model.inflection.Inflection;
 import com.annepolis.lexiconmeum.webapi.bff.textsearch.domain.FormMatch;
 import org.junit.jupiter.api.Test;
@@ -28,10 +28,10 @@ class TrieAutocompleteIndexTest {
     void trieReturnsAllMatchingWordsGivenPrefix(){
         String prefix = "test";
         String word = prefix + "word";
-        LexemeBuilder dLexemeBuilder = new LexemeBuilder(word, GrammaticalPosition.NOUN, "1");
+        LexemeBuilder dLexemeBuilder = new LexemeBuilder(word, PartOfSpeech.NOUN, "1");
         Lexeme lexeme = dLexemeBuilder.build();
 
-        LexemeBuilder cLexemeBuilder = new LexemeBuilder( word, GrammaticalPosition.VERB, "1");
+        LexemeBuilder cLexemeBuilder = new LexemeBuilder( word, PartOfSpeech.VERB, "1");
         Lexeme lexeme2 = cLexemeBuilder.build();
 
         TrieAutocompleteIndex underTest = new TrieAutocompleteIndex();


### PR DESCRIPTION
- **Refactor Lexeme Module**: Renamed `Position` to `PartOfSpeech` across models, DTOs, services, and tests for consistent terminology. Adjusted assemblers, contributors, mappers, pipelines, and utilities accordingly.
- **Testing Fixes**: Amended `equalsContract` verification to ignore `partOfSpeechDetails` to ensure flexibility.
- **Documentation**: Updated the roadmap to reflect progress on tasks related to adverbs, frontend automation, and testing.

This ensures better readability, uniformity, and alignment for domain-specific terms throughout the codebase.