### PR TITLE
Fix: auto-complete match suggestions not prioritized by alpha order

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.3</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <version>3.5.8</version>
+        <relativePath/> <!-- lookup parent from the repository -->
     </parent>
 
     <groupId>com.annepolis</groupId>
     <artifactId>lexiconmeum</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2-SNAPSHOT</version>
     <name>lexiconmeum</name>
     <description>lexiconmeum</description>
 
@@ -34,18 +34,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Override vulnerable spring-beans version -->
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-beans</artifactId>
-                <version>6.2.10</version> <!-- Use the patched version -->
-            </dependency>
-
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-webmvc</artifactId>
-                <version>6.2.10</version> <!-- Use the patched version -->
-            </dependency>
 
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.annepolis</groupId>
     <artifactId>lexiconmeum</artifactId>
-    <version>0.8.2-SNAPSHOT</version>
+    <version>0.8.2</version>
     <name>lexiconmeum</name>
     <description>lexiconmeum</description>
 

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/index/TrieAutocompleteIndex.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/index/TrieAutocompleteIndex.java
@@ -99,12 +99,13 @@ class TrieAutocompleteIndex implements AutocompleteIndexBackend {
 
         // Navigate down the trie searching for each character of the prefix array
         for (char prefixCharacter : prefix.toCharArray()) {
-            if (!node.getCharacterNodeMap().containsKey(prefixCharacter)) {
-                // If the prefix is not found, return an empty list
+            String normalizedPrefixCharacter = Normalizer.normalize(Character.toString(prefixCharacter), Normalizer.Form.NFD);
+            Character normalizedCharacterKey = normalizedPrefixCharacter.charAt(0);
+
+            if (!node.getCharacterNodeMap().containsKey(normalizedCharacterKey)) {
                 return results;
             }
-            //traverse to down the tree to the next node/char in the prefix
-            node = node.getCharacterNodeMap().get(prefixCharacter);
+            node = node.getCharacterNodeMap().get(normalizedCharacterKey);
         }
 
         // Once we've reached the end of the prefix,
@@ -157,7 +158,7 @@ class TrieAutocompleteIndex implements AutocompleteIndexBackend {
     }
 
     private static class TrieNode {
-        private final Map<Character, TrieNode> characterNodeMap = new HashMap<>();
+        private final Map<Character, TrieNode> characterNodeMap = new TreeMap<>();
         private char content;
         private boolean isEndOfWord;
         private final Set<UUID> lexemeIds = new HashSet<>();

--- a/src/test/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/index/TrieAutocompleteIndexTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/index/TrieAutocompleteIndexTest.java
@@ -59,6 +59,17 @@ class TrieAutocompleteIndexTest {
     }
 
     @Test
+    void matchingIgnoresDiacritics(){
+        TrieAutocompleteIndex underTest = new TrieAutocompleteIndex();
+        Lexeme lexeme = TestUtil.getNewTestNounLexeme();
+        for (Inflection inflection : lexeme.getInflections()){
+            underTest.insert(inflection.getForm(), lexeme.getId());
+        }
+        List<FormMatch> results = underTest.searchForMatchingForms("amīcō", 20);
+        assertEquals(3, results.size());
+    }
+
+    @Test
     void givenSuffixReturnsAllUniqueMatches(){
         TrieAutocompleteIndex underTest = new TrieAutocompleteIndex();
         List<Lexeme> lexemes = TestUtil.getMixedPartOfSpeechTestLexemes();


### PR DESCRIPTION
### Description

- Fixes issue where limit on matches would fill up and match returned would not necessarily be next alphabetically.
- Enhanced the autocomplete functionality with diacritic-insensitive matching by normalizing prefix characters.
- Added test cases to validate matching behavior for diacritics.
- Prepared for release 0.8.2 with version updates in `pom.xml`.