### PR TITLE
Refactor tense handling and DTO property consistency

### DIFF
--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/partofspeech/VerbDetails.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/partofspeech/VerbDetails.java
@@ -4,9 +4,10 @@ import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalTense;
 import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalVoice;
 import com.annepolis.lexiconmeum.shared.model.inflection.InflectionKey;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 
 public final class VerbDetails implements PartOfSpeechDetails {
 
@@ -15,7 +16,7 @@ public final class VerbDetails implements PartOfSpeechDetails {
 
     public VerbDetails(Builder builder) {
         this.morphologicalSubtype = builder.morphologicalSubtype;
-        this.participleDeclensionSets = Map.copyOf(builder.participleDeclensionSets);
+        this.participleDeclensionSets = Collections.unmodifiableMap(new TreeMap<>(builder.participleDeclensionSets));
     }
 
     public MorphologicalSubtype getMorphologicalSubtype() {
@@ -33,13 +34,13 @@ public final class VerbDetails implements PartOfSpeechDetails {
 
     public VerbDetails.Builder toBuilder() {
         VerbDetails.Builder builder = new VerbDetails.Builder().setMorphologicalSubtype(morphologicalSubtype);
-        getParticiples().values().forEach(ps -> builder.addParticipleSet(ps));
+        getParticiples().values().forEach(builder::addParticipleSet);
         return builder;
     }
 
     public static class Builder {
         private MorphologicalSubtype morphologicalSubtype;
-        private final Map<String, ParticipleDeclensionSet> participleDeclensionSets = new HashMap<>();
+        private final Map<String, ParticipleDeclensionSet> participleDeclensionSets = new TreeMap<>();
         
         public Builder setMorphologicalSubtype(MorphologicalSubtype morphologicalSubtype) {
             this.morphologicalSubtype = morphologicalSubtype;

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ConjugationGroupDTO.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ConjugationGroupDTO.java
@@ -7,21 +7,21 @@ import java.util.List;
 
 class ConjugationGroupDTO implements InflectionTableDTO {
 
-    @JsonProperty("conjugations")
-    private List<ConjugationTableDTO> conjugationTableDTOList;
 
-    @JsonProperty("participles")
-    private List<ParticipleTableDTO> participleTableDTOList;
+    private final List<ConjugationTableDTO> conjugationTableDTOList;
+    private final List<ParticipleTableDTO> participleTableDTOList;
 
     ConjugationGroupDTO(List<ConjugationTableDTO> tableDTOList, List<ParticipleTableDTO> participleTableDTOList){
         this.conjugationTableDTOList = tableDTOList;
         this.participleTableDTOList = participleTableDTOList;
     }
 
+    @JsonProperty("conjugations")
     public List<ConjugationTableDTO> getConjugationTableDTOList() {
         return conjugationTableDTOList;
     }
 
+    @JsonProperty("participles")
     public List<ParticipleTableDTO> getParticipleDTOList(){
         return participleTableDTOList;
     }

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ParticipleTableDTO.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ParticipleTableDTO.java
@@ -8,8 +8,9 @@ import java.util.List;
 import java.util.Map;
 
 public class ParticipleTableDTO implements InflectionTableDTO  {
-   String gender;
-   private List<ParticipleTenseDTO> tenses;
+
+    private String gender;
+    private List<ParticipleTenseDTO> tenses;
 
     public String getGender() {
         return gender;
@@ -23,7 +24,7 @@ public class ParticipleTableDTO implements InflectionTableDTO  {
         this.tenses = tenses;
     }
 
-    @JsonProperty("participles")
+    @JsonProperty("tenses")
     protected List<ParticipleTenseDTO> getTenses() {
         return tenses;
     }

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ParticipleTableMapper.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ParticipleTableMapper.java
@@ -17,6 +17,9 @@ import java.util.*;
 // create a declension table for each tense
 @Component
 public class ParticipleTableMapper {
+    // Comparator orders individual tense groups by natural enum order
+    Comparator<ParticipleDeclensionSet> participleDTOComparator =
+            Comparator.comparing(ParticipleDeclensionSet::getParticipleTense,Comparator.nullsLast(Comparator.naturalOrder()));
 
     public List<ParticipleTableDTO> toInflectionTableDTO(Lexeme lexeme) {
         // From the list of participle inflections grouped by tense
@@ -39,8 +42,12 @@ public class ParticipleTableMapper {
     Map<GrammaticalGender, List<ParticipleTableDTO.ParticipleTenseDTO>> getTenseDTOsByGender(Map<String, ParticipleDeclensionSet> participleSetMap){
         Map<GrammaticalGender, List<ParticipleTableDTO.ParticipleTenseDTO>> byGender = new LinkedHashMap<>();
 
+        // Sort the participle sets by tense using the comparator before processing
+        List<ParticipleDeclensionSet> sortedSets = new ArrayList<>(participleSetMap.values());
+        sortedSets.sort(participleDTOComparator);
+
         // For each participle set (all inflections for all genders for a given tense )
-        for (ParticipleDeclensionSet participleSet : participleSetMap.values()) {
+        for (ParticipleDeclensionSet participleSet : sortedSets) {
 
             // Extract all inflections for the given set (all inflections for all genders for current tense)
             Map<String, Inflection> inflections = participleSet.getInflectionIndex();
@@ -57,6 +64,7 @@ public class ParticipleTableMapper {
                 byGender.computeIfAbsent(gender, k -> new ArrayList<>()).add(tenseDTO);
             }
         }
+        
         return byGender;
     }
 


### PR DESCRIPTION
### Description
This pull request includes the following changes:

- **Participle Handling**: Introduced a comparator to ensure natural ordering of participle tenses in `ParticipleTableMapper`. Updated `VerbDetails` to use `TreeMap`, and refined mapping logic to process tense groups in a sorted order.
- **DTO Adjustments**: Reordered and adjusted JSON properties for consistency. Moved `@JsonProperty` annotations to getter methods in `ConjugationGroupDTO` and corrected a property name in `ParticipleTableDTO` from "participles" to "tenses."
