### PR TITLE
Update log4j2 configurations and suppress duplicate literal warnings

### DIFF
--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/GrammaticalParticipleTense.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/GrammaticalParticipleTense.java
@@ -1,5 +1,6 @@
 package com.annepolis.lexiconmeum.shared.model.grammar;
 
+@SuppressWarnings("java:S1192") // can't assume a change applies to all duplicate literals
 public enum GrammaticalParticipleTense {
     PARTICIPLE("Participle", "Participle"),
     PRESENT_ACTIVE("Present Active Participle", "Present Active Participle"),

--- a/src/main/resources/log4j2-dev.properties
+++ b/src/main/resources/log4j2-dev.properties
@@ -1,0 +1,53 @@
+status = warn
+name = DevConfig
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n
+
+
+appender.rolling.type = RollingFile
+appender.rolling.name = ROLLING
+appender.rolling.fileName = logs/app.log
+appender.rolling.filePattern = logs/app-%d{yyyy-MM-dd}-%i.log.gz
+appender.rolling.layout.type = PatternLayout
+appender.rolling.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %c - %m%n
+appender.rolling.policies.type = Policies
+appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.rolling.policies.time.interval = 1
+appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.rolling.policies.size.size = 10 MB
+appender.rolling.strategy.type = DefaultRolloverStrategy
+appender.rolling.strategy.max = 10
+
+rootLogger.level = warn
+rootLogger.appenderRefs = STDOUT,errorfile
+rootLogger.appenderRef.STDOUT.ref = STDOUT
+
+appender.file.type = File
+appender.file.name = PARSER_FILE
+appender.file.fileName = logs/parser-filter.log
+appender.file.append = true
+appender.file.layout.type = PatternLayout
+appender.file.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %c - %m%n
+
+logger.posParticipleParser.name = com.annepolis.lexiconmeum.ingest.wiktionary.POSParticipleParser
+logger.posParticipleParser.level = trace
+logger.posParticipleParser.additivity = false
+logger.posParticipleParser.appenderRefs = partparser
+logger.posParticipleParser.appenderRef.partparser.ref = PARSER_FILE
+
+appender.errorfile.type = File
+appender.errorfile.name = ERROR_FILE
+appender.errorfile.fileName = logs/ide-errors.log
+appender.errorfile.append = true
+appender.errorfile.layout.type = PatternLayout
+appender.errorfile.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %c - %m%n
+
+logger.wiktionaryParser.name = com.annepolis.lexiconmeum.ingest.wiktionary.WiktionaryLexicalDataParser
+logger.wiktionaryParser.level = error
+logger.wiktionaryParser.additivity = false
+logger.wiktionaryParser.appenderRefs = parser
+logger.wiktionaryParser.appenderRef.parser.ref = ERROR_FILE
+

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,4 +1,5 @@
 status = warn
+name = ProdConfig
 
 appender.console.type = Console
 appender.console.name = STDOUT
@@ -24,18 +25,7 @@ rootLogger.level = warn
 rootLogger.appenderRefs = STDOUT
 rootLogger.appenderRef.STDOUT.ref = STDOUT
 
-appender.file.type = File
-appender.file.name = PARSER_FILE
-appender.file.fileName = logs/parser-filter.log
-appender.file.append = true
-appender.file.layout.type = PatternLayout
-appender.file.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %c - %m%n
 
-logger.posParticipleParser.name = com.annepolis.lexiconmeum.ingest.wiktionary.POSParticipleParser
-logger.posParticipleParser.level = trace
-logger.posParticipleParser.additivity = false
-logger.posParticipleParser.appenderRefs = parser
-logger.posParticipleParser.appenderRef.parser.ref = PARSER_FILE
 
 
 


### PR DESCRIPTION
---

### Summary

This pull request updates the logging configurations for development and production environments and addresses warnings in the code.

### Changes
- Added `log4j2-dev.properties` for development logging.
- Cleaned up `log4j2.properties` by removing unused settings.
- Suppressed duplicate literals warnings in `GrammaticalParticipleTense` with `@SuppressWarnings("java:S1192")`.

### Checklist

- [ ] Tests cover the changes made
- [ ] Rebased against `main`
- [ ] Documentation updated (if necessary) 

---