### PR TITLE
Add support for adjective degree forms in search suggestions

### DIFF
--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/DataLinkingService.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/DataLinkingService.java
@@ -1,4 +1,3 @@
-
 package com.annepolis.lexiconmeum.ingest.wiktionary;
 
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
@@ -42,6 +41,9 @@ public class DataLinkingService {
                 Collections.synchronizedList(new ArrayList<>())
         ).add(dataToLink);
 
+        // Sometimes the parent-lemma of a non-lemma (linkable) will not be a 'Lexeme' lemma
+        // but the canonical form of another non-lemma - which in turn will point to a Lexeme lemma
+        // so storing not just parentLemmas of linkables, but also their lemmas -> parentLemma mapping
         linkableDataLemmaToParentLemma.computeIfAbsent(dataToLink.getLemma(), k ->
                 Collections.synchronizedList(new ArrayList<>())
         ).add(dataToLink.getLinkingLemma());
@@ -63,16 +65,18 @@ public class DataLinkingService {
         AtomicInteger linkablesUnresolved = new AtomicInteger(0);
         Map<String, List<String>> unresolvedDetails = new ConcurrentHashMap<>();
 
-        // Process each lexeme parent associated with linkables staged in the parsing phase
+        // Process each lexeme parent associated with linkables staged in the parsing phase.
         stagedDataToLink.forEach((parentLemma, linkables) -> {
             logger.debug("Processing {} linkable(s) for lexeme '{}'", linkables.size(), parentLemma);
 
             List<Lexeme> parentLexemes = new ArrayList<>();
             if(!stagedLexemeCache.containsKey(parentLemma)){
-                // Check for mapping of non-lemma linkable parents to linkable lemmas to lexeme lemmas
+                // If no direct mapping to a Lexeme exists, check for a mapping to another non-lexeme
+                // and get their parent-lemmas.
                 List<String> parentLemmas = linkableDataLemmaToParentLemma.computeIfAbsent(parentLemma, k -> new CopyOnWriteArrayList<>());
+
+                // Pick up all Lexemes matching the above parentLemmas.
                 for(String lexemeLemma : parentLemmas){
-                    // attempt to retrieve staged lexeme lexemes matching lexeme lemma from lexeme lemma->linkable index
                     parentLexemes.addAll(stagedLexemeCache.getLexemesByLemma(lexemeLemma)) ;
                 }
             } else {
@@ -81,46 +85,45 @@ public class DataLinkingService {
 
             }
 
+            // If no matching parentLexemes exist, update the 'unresolved' stats and skip.
             if (parentLexemes.isEmpty()) {
-                logger.warn("No parent lexeme found for {} staged linkable(s) of '{}'",
-                        linkables.size(), parentLemma);
-                linkablesUnresolved.addAndGet(linkables.size());
-                unresolvedDetails.put(parentLemma, linkables.stream()
-                        .map(LinkableData::getLemma)
-                        .toList());
+                linkables.forEach(linkable ->
+                        markUnresolved(parentLemma, linkable, linkablesUnresolved, unresolvedDetails)
+                );
                 return;
             }
 
-            // Attach non-lemma forms to matching lexeme(s)
-            for (LinkableData dataToLink : linkables) {
-                Lexeme matchingParentLexeme = findMatchingVerb(parentLexemes, dataToLink);
+                // Attach non-lemma forms to matching lexeme(s)
+                for (LinkableData dataToLink : linkables) {
+                    // Refresh parent lexemes from any changes effected in the previous iteration
+                    List<Lexeme> currentParentLexemes = stagedLexemeCache.getLexemesByLemma(parentLemma);
+                    
+                    if (currentParentLexemes.isEmpty()) {
+                        markUnresolved(parentLemma, dataToLink, linkablesUnresolved, unresolvedDetails);
+                        continue;
+                    }
+                    
+                    Lexeme matchingParentLexeme = findMatchingVerb(currentParentLexemes, dataToLink);
 
-                if (matchingParentLexeme != null) {
-                    Lexeme updatedVerb = dataToLink.link(matchingParentLexeme);
+                    if (matchingParentLexeme != null) {
+                        Lexeme updatedVerb = dataToLink.link(matchingParentLexeme);
 
-                    // Update the staged cache with the new version
-                    stagedLexemeCache.replaceLexeme(matchingParentLexeme, updatedVerb);
+                        // Update the staged cache with the new version
+                        stagedLexemeCache.replaceLexeme(matchingParentLexeme, updatedVerb);
 
-                    // Use callback instead of direct sink access
-                    reingestCallback.accept(updatedVerb);
+                        // Use callback instead of direct sink access
+                        reingestCallback.accept(updatedVerb);
 
-                    linkablesAttached.incrementAndGet();
+                        linkablesAttached.incrementAndGet();
 
-                    // refresh so the next iteration picks up any updates
-                    parentLexemes = stagedLexemeCache.getLexemesByLemma(parentLemma);
-                    logger.trace("Attached linkable '{}' ({}) to lexeme '{}'",
-                            dataToLink.getLemma(),
-                            dataToLink.getDataKey(),
-                            matchingParentLexeme.getLemma());
-                } else {
-                    logger.warn("Could not match linkable '{}' to any lexeme with lemma '{}'",dataToLink.getLemma(), parentLemma);
-
-                    linkablesUnresolved.incrementAndGet();
-                    unresolvedDetails.computeIfAbsent(
-                            parentLemma, k -> Collections.synchronizedList(new ArrayList<>()))
-                            .add(dataToLink.getLemma());
+                        logger.trace("Attached linkable '{}' ({}) to lexeme '{}'",
+                                dataToLink.getLemma(),
+                                dataToLink.getDataKey(),
+                                matchingParentLexeme.getLemma());
+                    } else {
+                        markUnresolved(parentLemma, dataToLink, linkablesUnresolved, unresolvedDetails);
+                    }
                 }
-            }
             lexemesUpdated.incrementAndGet();
         });
 
@@ -136,14 +139,6 @@ public class DataLinkingService {
         return report;
     }
 
-    public int getStagedCount() {
-        return stagedDataToLink.values().stream().mapToInt(List::size).sum();
-    }
-
-    public void clearStaged() {
-        stagedDataToLink.clear();
-    }
-
     private Lexeme findMatchingVerb(List<Lexeme> candidateLexemes, LinkableData dataToLink) {
         if (candidateLexemes.size() == 1) {
             return candidateLexemes.get(0);
@@ -155,6 +150,23 @@ public class DataLinkingService {
                 .filter(v -> v.getCanonicalForm().equals(targetCanonical))
                 .findFirst()
                 .orElse(candidateLexemes.get(0)); // Fallback to first if no exact match
+    }
+
+    private static void markUnresolved(String parentLemma, LinkableData dataToLink, AtomicInteger linkablesUnresolved, Map<String, List<String>> unresolvedDetails) {
+        logger.warn("Could not match linkable '{}' to any lexeme with lemma '{}'",dataToLink.getLemma(), parentLemma);
+
+        linkablesUnresolved.incrementAndGet();
+        unresolvedDetails.computeIfAbsent(
+                        parentLemma, k -> Collections.synchronizedList(new ArrayList<>()))
+                .add(dataToLink.getLemma());
+    }
+
+    public int getStagedCount() {
+        return stagedDataToLink.values().stream().mapToInt(List::size).sum();
+    }
+
+    public void clearStaged() {
+        stagedDataToLink.clear();
     }
 
     public record FinalizationReport(int lexemesUpdated, int linkablesAttached, int linkablesUnresolved,

--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/POSAdjectiveParser.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/POSAdjectiveParser.java
@@ -91,9 +91,13 @@ public class POSAdjectiveParser implements PartOfSpeechParser {
         }
     }
 
+
     // Filter out form nodes in black-list
     private boolean isDeclensionForm(JsonNode formNode){
-        if(!parserSupport.isValidFormNode(formNode, PartOfSpeech.ADJECTIVE.getInflectionType())) {
+        if(!parserSupport.isValidForm(formNode)) {
+            return false;
+        }
+        if (!formNode.has(SOURCE.get())) {
             return false;
         }
         String source = formNode.path(SOURCE.get()).asText();
@@ -102,7 +106,7 @@ public class POSAdjectiveParser implements PartOfSpeechParser {
         String formValue = formNode.path(FORM.get()).asText();
 
         if (!DECLENSION.get().equalsIgnoreCase(source) && !INFLECTION.get().equalsIgnoreCase(source)){
-            logger.trace(WiktionaryLexicalDataParser.LogMsg.UNEXPECTED_INFLECTION_SOURCE, source, formValue);
+            logger.trace(ParserSupport.LogMsg.UNEXPECTED_INFLECTION_SOURCE, source, formValue);
         }
         return true;
     }

--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/POSVerbParser.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/POSVerbParser.java
@@ -90,7 +90,7 @@ public class POSVerbParser implements PartOfSpeechParser {
                     parserSupport.addCanonicalForm( formNode, lexemeBuilder);
                 }
             } catch (IllegalArgumentException | IllegalStateException ex) {
-                logger.trace(WiktionaryLexicalDataParser.LogMsg.SKIPPING_INVALID_FORM, ex.getMessage());
+                logger.trace(ParserSupport.LogMsg.SKIPPING_INVALID_FORM, ex.getMessage());
             }
         }
     }

--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/ParserSupport.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/ParserSupport.java
@@ -26,6 +26,8 @@ public class ParserSupport {
     static class LogMsg {
 
         static final String FAILED_TO_BUILD = "Failed to build lexeme: {}";
+        static final String SKIPPING_INVALID_FORM = "Skipping invalid form: {}";
+        static final String UNEXPECTED_INFLECTION_SOURCE = "Found an unexpected inflection source {} in form: {}";
         private LogMsg() {} // Prevent instantiation
     }
 
@@ -71,6 +73,10 @@ public class ParserSupport {
     public boolean isValidFormNode(JsonNode formNode, String inflectionType) {
         return formNode.path(SOURCE.get()).asText().equals(inflectionType)
                 && !ParserConstants.COMMON_FORM_BLACKLIST.contains(formNode.path(FORM.get()).asText());
+    }
+
+    public boolean isValidForm(JsonNode formNode){
+       return !ParserConstants.COMMON_FORM_BLACKLIST.contains(formNode.path(FORM.get()).asText());
     }
 
     /**

--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataParser.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataParser.java
@@ -23,12 +23,9 @@ import static com.annepolis.lexiconmeum.ingest.wiktionary.WiktionaryLexicalDataJ
 class WiktionaryLexicalDataParser {
 
     static final Logger logger = LogManager.getLogger(WiktionaryLexicalDataParser.class);
-    private static final Marker NON_LEMMA = MarkerManager.getMarker("NON_LEMMA");
     private static final Marker PARSER_DELEGATION_ISSUE = MarkerManager.getMarker("PARSER_DELEGATION_ISSUE");
 
     static class LogMsg {
-        static final String SKIPPING_INVALID_FORM = "Skipping invalid form: {}";
-        static final String UNEXPECTED_INFLECTION_SOURCE = "Found an unexpected inflection source {} in form: {}";
         private static final String JSONL_FORMAT_ERROR = "Check that JSONL is correctly formatted and not 'prettified'";
         private static final String MISSING_NODES = "{} not found";
 

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/domain/DelegatingSearchableFormsExtractorConfig.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/domain/DelegatingSearchableFormsExtractorConfig.java
@@ -15,12 +15,13 @@ public class DelegatingSearchableFormsExtractorConfig {
     public DelegatingSearchableFormsExtractor defaultSearchableFormsExtractor(
             SearchableInflectedFormsExtractor inflectedFormsProvider,
             SearchableUninflectedFormsExtractor uninflectedFormsProvider,
-            SearchableVerbFormsExtractor verbFormsProvider
+            SearchableVerbFormsExtractor verbFormsProvider,
+            SearchableAdjectiveFormsExtractor adjectiveFormProvider
 
     ){
         Map<PartOfSpeech, SearchableFormsExtractor> formsExtractors = new EnumMap<>(PartOfSpeech.class);
 
-        formsExtractors.put(PartOfSpeech.ADJECTIVE, inflectedFormsProvider);
+        formsExtractors.put(PartOfSpeech.ADJECTIVE, adjectiveFormProvider);
         formsExtractors.put(PartOfSpeech.ADVERB, uninflectedFormsProvider);
         formsExtractors.put(PartOfSpeech.CONJUNCTION, uninflectedFormsProvider);
         formsExtractors.put(PartOfSpeech.DETERMINER, inflectedFormsProvider);

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/domain/SearchableAdjectiveFormsExtractor.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/domain/SearchableAdjectiveFormsExtractor.java
@@ -1,0 +1,50 @@
+package com.annepolis.lexiconmeum.webapi.bff.textsearch.domain;
+
+import com.annepolis.lexiconmeum.shared.model.Lexeme;
+import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.AdjectiveDetails;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+public class SearchableAdjectiveFormsExtractor implements SearchableFormsExtractor{
+
+    private final SearchableInflectedFormsExtractor baseExtractor;
+
+    public SearchableAdjectiveFormsExtractor(SearchableInflectedFormsExtractor baseExtractor) {
+        this.baseExtractor = baseExtractor;
+    }
+
+    @Override
+    public Set<String> getSearchableForms(Lexeme lexeme) {
+
+        // Get regular conjugation forms using base extractor
+        Set<String> forms = new LinkedHashSet<>(baseExtractor.getSearchableForms(lexeme));
+
+        // Add adjective forms if present
+        if (lexeme.getPartOfSpeechDetails() instanceof AdjectiveDetails adjectiveDetails) {
+            extractAdjectiveForms(adjectiveDetails, forms);
+        }
+        return Set.copyOf(forms);
+    }
+
+    /**
+     * Extract all inflected forms from all adjective sets
+     */
+    private void extractAdjectiveForms(AdjectiveDetails adjectiveDetails, Set<String> forms) {
+        adjectiveDetails.getDegreeInflections().values().forEach(adjectiveDegreeAgreementSet -> {
+            // Extract each inflected form (and its alternative if present)
+            adjectiveDegreeAgreementSet.getInflectionIndex().values().forEach(adjective -> {
+                Optional.ofNullable(adjective.getForm())
+                        .filter(s -> !s.isBlank())
+                        .ifPresent(forms::add);
+
+                Optional.ofNullable(adjective.getAlternativeForm())
+                        .filter(s -> !s.isBlank())
+                        .ifPresent(forms::add);
+            });
+        });
+    }
+}


### PR DESCRIPTION
---

### Description

This pull request refactors the parser to add support for integrating adjective degree forms into search suggestions. Key changes include:

- Fixed a bug in `DataLinkingService` involving incorrect variable usage, which was leading to invalid parent-lemma mappings.
- Introduced a new `SearchableAdjectiveFormsExtractor` specifically for processing adjective forms.
- Updated `DelegatingSearchableFormsExtractorConfig` to integrate the new adjective form extractor seamlessly.
