### PR TITLE
Enhance linking service with POS-aware lexeme resolution

### DIFF
--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/DataLinkingService.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/DataLinkingService.java
@@ -1,14 +1,14 @@
 package com.annepolis.lexiconmeum.ingest.wiktionary;
 
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.PartOfSpeech;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -21,9 +21,11 @@ import java.util.function.Consumer;
  */
 @Component
 public class DataLinkingService {
-    private static final Logger logger = LoggerFactory.getLogger(DataLinkingService.class);
+    private static final Logger logger = LogManager.getLogger(DataLinkingService.class);
+    private static final Marker MISSING_ADJECTIVE_LEXEME = MarkerManager.getMarker("MISSING_ADJECTIVE_LEXEME");
 
     // Thread-safe staging map for non-lemma forms waiting for their parent lexemes
+
     private final Map<String, List<LinkableData>> stagedDataToLink = new ConcurrentHashMap<>();
 
     // Some 'form_of' attributes point to that non-lemma form's main form, not the parent's lemma form
@@ -69,60 +71,31 @@ public class DataLinkingService {
         stagedDataToLink.forEach((parentLemma, linkables) -> {
             logger.debug("Processing {} linkable(s) for lexeme '{}'", linkables.size(), parentLemma);
 
-            List<Lexeme> parentLexemes = new ArrayList<>();
-            if(!stagedLexemeCache.containsKey(parentLemma)){
-                // If no direct mapping to a Lexeme exists, check for a mapping to another non-lexeme
-                // and get their parent-lemmas.
-                List<String> parentLemmas = linkableDataLemmaToParentLemma.computeIfAbsent(parentLemma, k -> new CopyOnWriteArrayList<>());
-
-                // Pick up all Lexemes matching the above parentLemmas.
-                for(String lexemeLemma : parentLemmas){
-                    parentLexemes.addAll(stagedLexemeCache.getLexemesByLemma(lexemeLemma)) ;
-                }
-            } else {
-                // attempt to retrieve staged lexeme lexemes matching lexeme lemma from lexeme lemma->linkable index
-                parentLexemes = stagedLexemeCache.getLexemesByLemma(parentLemma);
-
-            }
-
-            // If no matching parentLexemes exist, update the 'unresolved' stats and skip.
-            if (parentLexemes.isEmpty()) {
-                linkables.forEach(linkable ->
-                        markUnresolved(parentLemma, linkable, linkablesUnresolved, unresolvedDetails)
-                );
-                return;
-            }
-
                 // Attach non-lemma forms to matching lexeme(s)
                 for (LinkableData dataToLink : linkables) {
-                    // Refresh parent lexemes from any changes effected in the previous iteration
-                    List<Lexeme> currentParentLexemes = stagedLexemeCache.getLexemesByLemma(parentLemma);
-                    
-                    if (currentParentLexemes.isEmpty()) {
+
+                    Optional<Lexeme> maybeMatchingParentLexeme = findMatchingLexeme(parentLemma, dataToLink, stagedLexemeCache);
+                    // If no matching parentLexemes exist, update the 'unresolved' stats and skip.
+                    if(maybeMatchingParentLexeme.isEmpty()){
                         markUnresolved(parentLemma, dataToLink, linkablesUnresolved, unresolvedDetails);
                         continue;
                     }
-                    
-                    Lexeme matchingParentLexeme = findMatchingVerb(currentParentLexemes, dataToLink);
+                    Lexeme matchingParentLexeme = maybeMatchingParentLexeme.get();
 
-                    if (matchingParentLexeme != null) {
-                        Lexeme updatedVerb = dataToLink.link(matchingParentLexeme);
+                    Lexeme updatedLexeme = dataToLink.link(matchingParentLexeme);
 
-                        // Update the staged cache with the new version
-                        stagedLexemeCache.replaceLexeme(matchingParentLexeme, updatedVerb);
+                    // Update the staged cache with the new version
+                    stagedLexemeCache.replaceLexeme(matchingParentLexeme, updatedLexeme);
 
-                        // Use callback instead of direct sink access
-                        reingestCallback.accept(updatedVerb);
+                    // Use callback instead of direct sink access
+                    reingestCallback.accept(updatedLexeme);
 
-                        linkablesAttached.incrementAndGet();
+                    linkablesAttached.incrementAndGet();
 
-                        logger.trace("Attached linkable '{}' ({}) to lexeme '{}'",
-                                dataToLink.getLemma(),
-                                dataToLink.getDataKey(),
-                                matchingParentLexeme.getLemma());
-                    } else {
-                        markUnresolved(parentLemma, dataToLink, linkablesUnresolved, unresolvedDetails);
-                    }
+                    logger.trace("Attached linkable '{}' ({}) to lexeme '{}'",
+                            dataToLink.getLemma(),
+                            dataToLink.getDataKey(),
+                            matchingParentLexeme.getLemma());
                 }
             lexemesUpdated.incrementAndGet();
         });
@@ -139,17 +112,45 @@ public class DataLinkingService {
         return report;
     }
 
-    private Lexeme findMatchingVerb(List<Lexeme> candidateLexemes, LinkableData dataToLink) {
+    private Optional<Lexeme> findMatchingLexeme(String parentLemma, LinkableData dataToLink, StagedLexemeCache stagedLexemeCache) {
+
+        List<Lexeme> candidateLexemes = resolveCandidateLexemesToLink(parentLemma, dataToLink.getParentLinkPartOfSpeech(), stagedLexemeCache);
+        if(candidateLexemes.isEmpty()){
+            if(dataToLink.getParentLinkPartOfSpeech() == PartOfSpeech.ADJECTIVE){
+                logger.debug( MISSING_ADJECTIVE_LEXEME, "Missing parent {} of lemma {} ", parentLemma, dataToLink.getLemma());
+            }
+            return Optional.empty();
+        }
         if (candidateLexemes.size() == 1) {
-            return candidateLexemes.get(0);
+            return Optional.of(candidateLexemes.get(0));
         }
 
-        // Multiple lexemes with the same lemma - match by canonical form
+        // Multiple lexemes with the same lemma - match on macronized form
         String targetCanonical = dataToLink.getLinkingLemmaWithMacrons();
-        return candidateLexemes.stream()
+         return Optional.of(candidateLexemes.stream()
                 .filter(v -> v.getCanonicalForm().equals(targetCanonical))
                 .findFirst()
-                .orElse(candidateLexemes.get(0)); // Fallback to first if no exact match
+                .orElse(candidateLexemes.get(0))); // Fallback to first if no exact match
+    }
+
+    List<Lexeme> resolveCandidateLexemesToLink(String parentLemma, PartOfSpeech parentPartOfSpeech, StagedLexemeCache stagedLexemeCache){
+        List<Lexeme> candidateLexemes = new ArrayList<>();
+
+        // If no direct mapping to a Lexeme exists,
+        // check for a mapping to another non-lemma canonical parent and get its parent-lemmas.
+        if(!stagedLexemeCache.containsKey(parentLemma)) {
+            List<String> parentLemmas = getCanonicalParentLemmas(parentLemma);
+            for(String lemma :parentLemmas){
+                candidateLexemes.addAll(stagedLexemeCache.getLexemesByLemmaAndPos(lemma, parentPartOfSpeech));
+            }
+        } else {
+            candidateLexemes.addAll(stagedLexemeCache.getLexemesByLemmaAndPos(parentLemma, parentPartOfSpeech));
+        }
+        return candidateLexemes;
+    }
+
+    List<String> getCanonicalParentLemmas(String parentLemma){
+        return linkableDataLemmaToParentLemma.computeIfAbsent(parentLemma, k -> new CopyOnWriteArrayList<>());
     }
 
     private static void markUnresolved(String parentLemma, LinkableData dataToLink, AtomicInteger linkablesUnresolved, Map<String, List<String>> unresolvedDetails) {

--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/LinkableData.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/LinkableData.java
@@ -1,6 +1,7 @@
 package com.annepolis.lexiconmeum.ingest.wiktionary;
 
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
+import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.PartOfSpeech;
 
 public interface LinkableData {
 
@@ -9,5 +10,6 @@ public interface LinkableData {
     String getLinkingLemmaWithMacrons();
     Lexeme link(Lexeme lexeme);
     String getDataKey();
+    PartOfSpeech getParentLinkPartOfSpeech();
 
 }

--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/StagedAdjectiveDegreeData.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/StagedAdjectiveDegreeData.java
@@ -4,6 +4,7 @@ import com.annepolis.lexiconmeum.shared.model.Lexeme;
 import com.annepolis.lexiconmeum.shared.model.LexemeBuilder;
 import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.AdjectiveDegreeAgreementSet;
 import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.AdjectiveDetails;
+import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.PartOfSpeech;
 
 public class StagedAdjectiveDegreeData implements LinkableData {
     
@@ -61,5 +62,10 @@ public class StagedAdjectiveDegreeData implements LinkableData {
     @Override
     public String getDataKey() {
         return adjectiveDegreeAgreementSet.getGrammaticalDegree().name();
+    }
+
+    @Override
+    public PartOfSpeech getParentLinkPartOfSpeech() {
+        return PartOfSpeech.ADJECTIVE;
     }
 }

--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/StagedLexemeCache.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/StagedLexemeCache.java
@@ -3,6 +3,7 @@ package com.annepolis.lexiconmeum.ingest.wiktionary;
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
 import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalTense;
 import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalVoice;
+import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.PartOfSpeech;
 import com.annepolis.lexiconmeum.shared.model.inflection.InflectionKey;
 import com.annepolis.lexiconmeum.shared.util.Utilities;
 import org.apache.logging.log4j.LogManager;
@@ -24,6 +25,9 @@ public class StagedLexemeCache {
 
     private final Map<String, List<Lexeme>> lemmaToLexemesLookup = new ConcurrentHashMap<>();
 
+    // NEW: Compound index by lemma + POS for faster filtering
+    private final Map<String, List<Lexeme>> lemmaAndPosToLexemesLookup = new ConcurrentHashMap<>();
+
     private final Map<String, Lexeme> gerundiveFormToLexemeLookup = new ConcurrentHashMap<>();
 
     private final String gerundiveKey = InflectionKey.buildParticipleSetKey(GrammaticalVoice.PASSIVE, GrammaticalTense.FUTURE);
@@ -35,6 +39,13 @@ public class StagedLexemeCache {
 
         lemmaToLexemesLookup
                 .computeIfAbsent(lexeme.getLemma(), k -> new CopyOnWriteArrayList<>())
+                .add(lexeme);
+
+        // Add to compound lemma+POS index
+        String compoundKey = buildCompoundKey(lexeme.getLemma(), lexeme.getPartOfSpeech());
+
+        lemmaAndPosToLexemesLookup
+                .computeIfAbsent(compoundKey, k -> new CopyOnWriteArrayList<>())
                 .add(lexeme);
 
         putGerundiveEntry(lexeme);
@@ -57,6 +68,14 @@ public class StagedLexemeCache {
             lemmaList.add(newLexeme);
         }
 
+        // Update compound index - remove old, add new
+        String compoundKey = buildCompoundKey(newLexeme.getLemma(), newLexeme.getPartOfSpeech());
+        List<Lexeme> compoundList = lemmaAndPosToLexemesLookup.get(compoundKey);
+        if (compoundList != null) {
+            compoundList.remove(oldLexeme);
+            compoundList.add(newLexeme);
+        }
+
         putGerundiveEntry(newLexeme);
 
         logger.debug("Replaced lexeme in all indexes: {}", newLexeme);
@@ -71,9 +90,19 @@ public class StagedLexemeCache {
         }
     }
 
-    public List<Lexeme> getLexemesByLemma(String lemma) {
-        List<Lexeme> lexemes = lemmaToLexemesLookup.get(lemma);
-        return lexemes != null ? List.copyOf(lexemes) : getLexemeByGerundive(lemma);
+    public List<Lexeme> getLexemesByLemmaAndPos(String lemma, PartOfSpeech partOfSpeech) {
+        String compoundKey = buildCompoundKey(lemma, partOfSpeech);
+        List<Lexeme> lexemes = lemmaAndPosToLexemesLookup.get(compoundKey);
+        if (lexemes != null) {
+            return List.copyOf(lexemes);
+        } else {
+            if (partOfSpeech == PartOfSpeech.VERB) return getLexemeByGerundive(lemma);
+            return List.of();
+        }
+    }
+
+    private String buildCompoundKey(String lemma, PartOfSpeech pos) {
+        return lemma + "|" + pos.name();
     }
 
     public List<Lexeme> getLexemeByGerundive(String gerundive){
@@ -83,8 +112,8 @@ public class StagedLexemeCache {
 
     public boolean containsKey(String key){
         return lemmaToLexemesLookup.containsKey(key)
-        || gerundiveFormToLexemeLookup.containsKey(key);
-
+        || gerundiveFormToLexemeLookup.containsKey(key)
+        || lemmaAndPosToLexemesLookup.containsKey(key);
     }
 
     /**

--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/StagedParticipleData.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/StagedParticipleData.java
@@ -2,6 +2,7 @@ package com.annepolis.lexiconmeum.ingest.wiktionary;
 
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
 import com.annepolis.lexiconmeum.shared.model.LexemeBuilder;
+import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.PartOfSpeech;
 import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.ParticipleDeclensionSet;
 import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.VerbDetails;
 import com.annepolis.lexiconmeum.shared.model.inflection.InflectionKey;
@@ -104,4 +105,11 @@ public class StagedParticipleData implements LinkableData{
     public String getDataKey() {
        return getParticipleKey();
     }
+
+    @Override
+    public PartOfSpeech getParentLinkPartOfSpeech() {
+        return PartOfSpeech.VERB;
+    }
+
+
 }

--- a/src/main/resources/log4j2-dev.properties
+++ b/src/main/resources/log4j2-dev.properties
@@ -38,6 +38,24 @@ logger.posParticipleParser.additivity = false
 logger.posParticipleParser.appenderRefs = partparser
 logger.posParticipleParser.appenderRef.partparser.ref = PARSER_FILE
 
+appender.linkerFile.type = File
+appender.linkerFile.name = LINKER_FILE
+appender.linkerFile.fileName = logs/linker.log
+appender.linkerFile.append = true
+appender.linkerFile.layout.type = PatternLayout
+appender.linkerFile.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %c - %m%n
+
+appender.linkerFile.filter.marker.type = MarkerFilter
+appender.linkerFile.filter.marker.marker = MISSING_ADJECTIVE_LEXEME
+appender.linkerFile.filter.marker.onMatch = ACCEPT
+appender.linkerFile.filter.marker.onMismatch = DENY
+
+logger.dataLinkingService.name = com.annepolis.lexiconmeum.ingest.wiktionary.DataLinkingService
+logger.dataLinkingService.level = debug
+logger.dataLinkingService.additivity = false
+logger.dataLinkingService.appenderRefs = linker
+logger.dataLinkingService.appenderRef.linker.ref = LINKER_FILE
+
 appender.errorfile.type = File
 appender.errorfile.name = ERROR_FILE
 appender.errorfile.fileName = logs/ide-errors.log


### PR DESCRIPTION
### Description of Changes

This pull request enhances the linking service by introducing POS-aware lexeme resolution. The following changes have been implemented:
- Added a compound index (lemma + POS) to `StagedLexemeCache` for improved filtering.
- Introduced new methods for resolving lexemes by lemma and POS, enabling more precise parent lexeme matching.
- Updated the `DataLinkingService` to use POS-specific logic with fallback options for parent lemma matches.
- Improved logging for unresolved adjective linkables, providing better tracking and analysis.
- Updated the `LinkableData` interface and its implementations to include metadata for POS-based linking.
