### PR TITLE
Add documentation for agent testing and operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,13 @@ HELP.md
 
 *.log
 *.versionsBackup
+
+### Local OS metadata ###
+.DS_Store
+**/.DS_Store
+
+### Local runtime output ###
+logs/
+
+### Node tooling ###
+node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository.
+
+## Project Snapshot
+
+LexiconMeum is a Java 21 Spring Boot backend for a Latin vocabulary search and grammar tool. It loads pre-parsed Wiktionary/Kaikki lexical data, builds in-memory lookup structures, and exposes REST endpoints for autocomplete and lexeme detail views.
+
+## Canonical Commands
+
+- Run all tests: `./mvnw test`
+- Run one test class: `./mvnw -Dtest=ClassName test`
+- Run one test method: `./mvnw -Dtest=ClassName#methodName test`
+- Package the app: `./mvnw clean package`
+- Run locally: `./mvnw spring-boot:run -Dspring-boot.run.profiles=local`
+
+Prefer the Maven wrapper over a system Maven install.
+
+## Package Map
+
+- Wiktionary parsing/staging/linking: `src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary`
+- Raw tag mapping: `src/main/java/com/annepolis/lexiconmeum/ingest/tagmapping`
+- Core domain model: `src/main/java/com/annepolis/lexiconmeum/shared/model`
+- Shared reader/sink abstractions and exceptions: `src/main/java/com/annepolis/lexiconmeum/shared`
+- In-memory lexeme cache: `src/main/java/com/annepolis/lexiconmeum/cache/inmemory`
+- API routes, response keys, CORS, properties: `src/main/java/com/annepolis/lexiconmeum/webapi`
+- Autocomplete/text search: `src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch`
+- Lexeme detail response assembly: `src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail`
+- Runtime config and bundled lexical data: `src/main/resources`
+- Tests: `src/test/java`
+- Test fixtures and test config: `src/test/resources`
+
+## Architecture Pointers
+
+- Architecture and module responsibilities: `ARCHITECTURE.md`
+- Public context, endpoint examples, deployment notes: `README.md`
+- Planned direction: `ROADMAP.md`
+
+Treat source and tests as the authority for current behavior.
+
+## Testing Expectations
+
+Add focused tests when behavior changes.
+
+- Parser, tag mapping, model: unit tests near the affected package
+- Web API behavior: controller or integration coverage
+- Narrow refactor: closest existing tests, plus `./mvnw test` when practical
+
+Do not add tests for documentation-only changes unless explicitly asked.
+
+## Data And Fixtures
+
+The JSONL files under `src/main/resources` and `src/test/resources` are lexical data inputs and fixtures. Keep changes to them intentional and small. When changing parser behavior, prefer adding or editing the smallest relevant test fixture instead of broad data churn.
+
+`src/main/resources/lexicalDataPartial.jsonl` is bundled application data. Avoid reformatting or mass-editing it as part of unrelated changes.
+
+## API Conventions
+
+Route constants live under `webapi`, especially `ApiRoutes`. Keep endpoint paths and response-key constants centralized instead of duplicating literals through controllers or tests.
+
+The BFF packages should expose response shapes useful to the frontend rather than leaking parser internals directly.
+
+## Implementation Preferences
+
+- Follow existing Spring configuration patterns before introducing new infrastructure.
+- Prefer domain objects and typed grammar enums over raw strings for grammatical concepts.
+- Keep parsing concerns in `ingest` and API presentation concerns in `webapi/bff`.
+- Keep shared abstractions small; avoid moving feature-specific behavior into `shared` unless it is genuinely reused.
+- Preserve existing release/deploy conventions unless the task is specifically about changing them.
+
+## Local Noise
+
+Ignore IDE files, OS metadata, logs, dependency folders, and Maven build output. Do not treat local `.DS_Store`, `logs/`, `node_modules/`, or `target/` changes as meaningful project changes.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,143 @@
+# LexiconMeum Architecture
+
+This document summarizes the backend structure for contributors and coding agents.
+
+## Overview
+
+LexiconMeum is a Spring Boot service that provides Latin lexical lookup APIs. The backend ingests machine-readable Wiktionary/Kaikki lexical data, maps it into domain objects, stores lexemes in an in-memory cache, builds text-search indexes, and serves frontend-oriented REST responses.
+
+At a high level:
+
+```text
+Wiktionary/Kaikki JSONL
+        |
+        v
+ingest/wiktionary parsers and staging
+        |
+        v
+tagmapping factories
+        |
+        v
+shared Lexeme domain model
+        |
+        v
+in-memory cache and search indexes
+        |
+        v
+webapi BFF controllers and response assemblers
+```
+
+## Runtime Data Flow
+
+The application loads bundled lexical data from `src/main/resources/lexicalDataPartial.jsonl`. Ingest components parse raw entries into lexeme objects, normalize grammatical features, and link related lexical records where needed. The resulting lexemes are stored behind shared reader/sink abstractions and served through the web API.
+
+Text search builds searchable forms from lexemes, including principal forms and inflected forms where supported. Autocomplete requests query an index implementation and map matched lexemes into suggestion responses.
+
+Lexeme detail requests retrieve a lexeme by id and assemble a frontend-oriented response from section contributors. Each contributor owns one piece of the response, such as definitions, principal parts, gender, subtype, inflection class, or inflection tables.
+
+## Fast Lookup
+
+- Parser behavior: `src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary`
+- Raw tag mapping: `src/main/java/com/annepolis/lexiconmeum/ingest/tagmapping`
+- Domain grammar/model: `src/main/java/com/annepolis/lexiconmeum/shared/model`
+- Runtime lexeme cache: `src/main/java/com/annepolis/lexiconmeum/cache/inmemory`
+- Autocomplete/text search: `src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch`
+- Lexeme detail response: `src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail`
+- Routes, response keys, CORS, properties: `src/main/java/com/annepolis/lexiconmeum/webapi`
+- Runtime data: `src/main/resources/lexicalDataPartial.jsonl`
+- Test fixtures: `src/test/resources`
+
+## Main Modules
+
+### Ingest
+
+`src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary` contains parsing and staging logic for raw Wiktionary/Kaikki data. Part-of-speech-specific parser classes handle nouns, verbs, adjectives, participles, conjunctions, and non-inflected forms.
+
+`src/main/java/com/annepolis/lexiconmeum/ingest/tagmapping` maps raw tags into typed domain concepts such as part-of-speech details, inflection classes, and inflection features.
+
+Parser changes should stay close to the relevant parser or factory unless the same rule is reused across multiple parts of speech.
+
+### Shared Domain
+
+`src/main/java/com/annepolis/lexiconmeum/shared/model` contains the core model:
+
+- `Lexeme`, `Sense`, and builders.
+- Inflection objects and inflection keys.
+- Grammar enums for case, number, gender, person, tense, mood, voice, degree, and related concepts.
+- Part-of-speech detail types.
+
+The shared model should remain independent of controller response shapes. Prefer typed grammar concepts here instead of raw strings.
+
+### Cache
+
+`src/main/java/com/annepolis/lexiconmeum/cache/inmemory` contains the in-memory cache implementation. The cache is the runtime lookup layer between loaded lexical data and API use cases.
+
+### Text Search BFF
+
+`src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch` owns autocomplete behavior.
+
+Important responsibilities:
+
+- Extract searchable forms from lexemes.
+- Route lexemes to the appropriate form extractor.
+- Build and query autocomplete indexes.
+- Map matched entries into suggestion responses.
+- Serve text-search endpoints through `TextSearchController`.
+
+The search layer should handle frontend search needs without leaking parsing-stage details.
+
+### Lexeme Detail BFF
+
+`src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail` owns lexeme detail responses.
+
+Important responsibilities:
+
+- Retrieve the requested lexeme.
+- Select and assemble response sections.
+- Convert domain inflections into table-oriented DTOs.
+- Keep response assembly modular through `LexemeDetailSectionContributor` implementations.
+
+When adding a new detail field, look first for an existing section contributor that owns that concept. Add a new contributor only when the response section is distinct enough to deserve its own assembly path.
+
+### Web API
+
+`src/main/java/com/annepolis/lexiconmeum/webapi` contains route constants, API response keys, CORS configuration, and web properties.
+
+Keep route paths and shared response-key literals centralized here.
+
+## Configuration
+
+Runtime configuration lives in `src/main/resources`:
+
+- Default: `application.yml`
+- Local profile: `application-local.yml`
+- Development profile: `application-dev.yml`
+- Logging: `log4j2.properties`, `log4j2-dev.properties`
+
+Tests use `src/test/resources/application-test.yml`.
+
+## Testing Strategy
+
+Tests are organized near the behavior they cover:
+
+- Parser: `src/test/java/com/annepolis/lexiconmeum/ingest/wiktionary`
+- Tag mapping: `src/test/java/com/annepolis/lexiconmeum/ingest/tagmapping` and related grammar tests
+- Domain model: `src/test/java/com/annepolis/lexiconmeum/shared/model`
+- Text search: `src/test/java/com/annepolis/lexiconmeum/webapi/bff/textsearch`
+- Lexeme detail and inflection tables: `src/test/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail`
+
+Use focused fixtures from `src/test/resources` when possible. Keep fixture edits small and targeted; do not rewrite JSONL data unless the task is specifically about data regeneration.
+
+## Deployment
+
+CI runs Maven tests on pull requests and pushes to `develop` and `master`. Deployment is handled by the GitHub Actions workflow for pushes to `master`, which builds the JAR and deploys it to the VPS service.
+
+See `README.md` for release branch and versioning steps.
+
+## Design Constraints
+
+- Keep ingest/parsing concerns separate from BFF response assembly.
+- Keep domain grammar concepts typed.
+- Never rewrite JSONL data unless the task is specifically about data regeneration.
+- Favor small, package-local changes over cross-cutting abstractions.
+- Keep API response changes intentional because the frontend depends on these shapes.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: test test-one run-local package
+
+test:
+	./mvnw test
+
+test-one:
+	./mvnw -Dtest=$(TEST) test
+
+run-local:
+	./mvnw spring-boot:run -Dspring-boot.run.profiles=local
+
+package:
+	./mvnw clean package

--- a/src/test/resources/README.md
+++ b/src/test/resources/README.md
@@ -1,0 +1,33 @@
+# Test Resource Fixtures
+
+These resources are intentionally small samples of Wiktionary/Kaikki-style data
+and Spring test configuration. Prefer adding the narrowest fixture record needed
+for a behavior change instead of broad fixture churn.
+
+## JSONL Lexical Data
+
+Each `.jsonl` file contains one lexical JSON object per line. Parser tests load
+these files through `ClassPathResource` or `JsonTestDataManager`.
+
+| File | Scope | Notable entries | Common test uses |
+| --- | --- | --- | --- |
+| `testDataRaw.jsonl` | Mixed end-to-end parser sample with verbs, nouns, adjectives, pronouns, determiners, conjunctions, participles, duplicate lemmas, and invalid/non-lemma cases. | `sum`, `amo`, `poculum`, `pulcher`, `brevis`, `nox`, `etsi`, `pulso`, `ille`, `sequor`, plus participles such as `futurus`, `doctus`, `amans`, `sequendus`, and `amandus`. | Broad parser smoke tests, staging vs. consumed lexeme behavior, valid lemma filtering, duplicate lemma handling, participle parent lookup, and POS routing coverage. |
+| `testDataVerb.jsonl` | Verb-centered fixture for parsed verb lexemes and verb-like participle/noun collisions. | `sum`, `amo`, `sequor`, `amans` as both verb participle and noun, plus pronoun `sum`. | Verb parsing, conjugation DTO assembly, compound deponent forms, autocomplete/index tests involving verbs, and present active participle parsing. |
+| `testDataNoun.jsonl` | Noun-centered fixture with declension coverage and noun/adjective collisions. | `poculum`, `brevis` masculine/feminine noun entries, `nox`, and `amicus` as both adjective and noun. | Noun parsing, declension table mapping, autocomplete/index tests involving nouns, and same-lemma POS disambiguation. |
+| `testDataAdjective.jsonl` | Adjective fixture with positive, comparative, and superlative forms. | `pulcher`/`pulchrior`/`pulcherrimus`, `brevis`/`brevissimus`, `levis`/`levior`/`levissimus`, and participial adjective data such as `doctus`. | Adjective parser tests, degree handling, comparative/superlative routing, and adjective/noun ambiguity checks. |
+| `testDataquisqui.jsonl` | Focused `quis` fixture covering multiple POS interpretations. | `quis` as pronoun, determiner, and verb-like head entry. | Narrow POS key and pronoun/determiner parser scenarios. |
+
+When adding a valid lemma to `testDataRaw.jsonl`, also check the expected count
+lists in `WiktionaryLexicalDataParserTest`.
+
+## Structured JSON
+
+| File | Scope | Common test uses |
+| --- | --- | --- |
+| `participles.json` | Hand-built participle table fixture grouped by voice/tense keys: `ACTIVE|PRESENT`, `ACTIVE|FUTURE`, `PASSIVE|PERFECT`, and `PASSIVE|FUTURE`. | `ParticipleTableMapperTest` builds a synthetic `amo` verb lexeme with participle declension sets and verifies DTO table coverage by gender and tense. |
+
+## Spring Test Configuration
+
+| File | Scope | Common test uses |
+| --- | --- | --- |
+| `application-test.yml` | Test profile properties. Sets `test.base-url` and points application data loading at `classpath:lexicalDataPartial.jsonl`. | Spring Boot integration tests and controller tests that need predictable test profile settings. |


### PR DESCRIPTION
- **What does this PR do?**  
  Adds documentation and a Makefile for testing AI agents and running locally. Optimizes documentation tailored for improving AI agent operations.

- **Why are these changes necessary?**  
  To ensure easier agent testing and improve local operation workflows.

- **Additional context**  
  No related issues.