### PR TITLE
Upgrade dependencies and integrate OpenAPI support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md
+
+Guidance for AI coding agents working in this repository.
+
+## Project Snapshot
+
+LexiconMeum is a Java 21 Spring Boot backend for a Latin vocabulary search and grammar tool. It loads pre-parsed Wiktionary/Kaikki lexical data, builds in-memory lookup structures, and exposes REST endpoints for autocomplete and lexeme detail views.
+
+## Canonical Commands
+
+- Run all tests: `./mvnw test`
+- Run one test class: `./mvnw -Dtest=ClassName test`
+- Run one test method: `./mvnw -Dtest=ClassName#methodName test`
+- Package the app: `./mvnw clean package`
+- Run locally: `./mvnw spring-boot:run -Dspring-boot.run.profiles=local`
+
+Prefer the Maven wrapper over a system Maven install.
+
+## Package Map
+
+- Wiktionary parsing/staging/linking: `src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary`
+- Raw tag mapping: `src/main/java/com/annepolis/lexiconmeum/ingest/tagmapping`
+- Core domain model: `src/main/java/com/annepolis/lexiconmeum/shared/model`
+- Shared reader/sink abstractions and exceptions: `src/main/java/com/annepolis/lexiconmeum/shared`
+- In-memory lexeme cache: `src/main/java/com/annepolis/lexiconmeum/cache/inmemory`
+- API routes, response keys, CORS, properties: `src/main/java/com/annepolis/lexiconmeum/webapi`
+- Autocomplete/text search: `src/main/java/com/annepolis/lexiconmeum/webapi/bff/textsearch`
+- Lexeme detail response assembly: `src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail`
+- Runtime config and bundled lexical data: `src/main/resources`
+- Tests: `src/test/java`
+- Test fixtures and test config: `src/test/resources`
+
+## Architecture Pointers
+
+- Architecture and module responsibilities: `ARCHITECTURE.md`
+- Public context, endpoint examples, deployment notes: `README.md`
+- Planned direction: `ROADMAP.md`
+
+Treat source and tests as the authority for current behavior.
+
+## Testing Expectations
+
+Add focused tests when behavior changes.
+
+- Parser, tag mapping, model: unit tests near the affected package
+- Web API behavior: controller or integration coverage
+- Narrow refactor: closest existing tests, plus `./mvnw test` when practical
+
+Do not add tests for documentation-only changes unless explicitly asked.
+
+## Data And Fixtures
+
+The JSONL files under `src/main/resources` and `src/test/resources` are lexical data inputs and fixtures. Keep changes to them intentional and small. When changing parser behavior, prefer adding or editing the smallest relevant test fixture instead of broad data churn.
+
+`src/main/resources/lexicalDataPartial.jsonl` is bundled application data. Avoid reformatting or mass-editing it as part of unrelated changes.
+
+## API Conventions
+
+Route constants live under `webapi`, especially `ApiRoutes`. Keep endpoint paths and response-key constants centralized instead of duplicating literals through controllers or tests.
+
+The BFF packages should expose response shapes useful to the frontend rather than leaking parser internals directly.
+
+## Implementation Preferences
+
+- Follow existing Spring configuration patterns before introducing new infrastructure.
+- Prefer domain objects and typed grammar enums over raw strings for grammatical concepts.
+- Keep parsing concerns in `ingest` and API presentation concerns in `webapi/bff`.
+- Keep shared abstractions small; avoid moving feature-specific behavior into `shared` unless it is genuinely reused.
+- Preserve existing release/deploy conventions unless the task is specifically about changing them.
+
+## Local Noise
+
+Ignore IDE files, OS metadata, logs, dependency folders, and Maven build output. Do not treat local `.DS_Store`, `logs/`, `node_modules/`, or `target/` changes as meaningful project changes.

--- a/README.md
+++ b/README.md
@@ -19,28 +19,34 @@ Lexical data is sourced from [Wiktionary](https://www.wiktionary.org/) and parse
 
 ### 🔄 API Contract
 
+OpenAPI docs are generated at runtime:
+
+```bash
+GET /v3/api-docs
+GET /swagger-ui/index.html
+```
+
 ##### word search endpoint:
 
 given prefix (match beginning of word)
 ```bash
-GET /api/v1/autocomplete/prefix?prefix=<string>
+GET /api/v1/lexemes/autocomplete/prefix?prefix=<string>&limit=<integer>
 
-Response: JSON array of matching words (e.g.,
-["amare", "amatus"])
+Response: JSON array of suggestion objects.
 ```
 given suffix (match end of word)
 
 ```bash
-GET /api/v1/autocomplete/suffix?suffix=<string>
-Response: JSON array of matching words (e.g.,
-["amaturus", "amonibus, "]
+GET /api/v1/lexemes/autocomplete/suffix?suffix=<string>&limit=<integer>
+
+Response: JSON array of suggestion objects.
 ```
 ##### word detail endpoints
 ```bash
-GET /api/v1/lexemes/123/detail?type=<string>  #type is optional
+GET /api/v1/lexemes/{id}/detail?type=<string>  # type is optional
 GET /api/v1/lexemes?lexemeId=<string>
-Response: JSON object (e.g.,
-["amare", "amatus"])
+
+Response: JSON object.
 ```
 
 ## Versioning and Deployment

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.8</version>
+        <version>4.0.6</version>
         <relativePath/> <!-- lookup parent from the repository -->
     </parent>
 
@@ -36,9 +36,17 @@
         <dependencies>
 
             <dependency>
+                <groupId>org.springdoc</groupId>
+                <artifactId>springdoc-openapi-bom</artifactId>
+                <version>3.0.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-bom</artifactId>
-                <version>2.25.3</version>
+                <version>2.26.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -69,6 +77,11 @@
             </dependency>
 
             <dependency>
+                <groupId>org.springdoc</groupId>
+                <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            </dependency>
+
+            <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-test</artifactId>
                 <scope>test</scope>
@@ -91,12 +104,11 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
             </dependency>
+
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
-                <version>2.25.3</version>
             </dependency>
-
 
             <dependency>
                 <groupId>org.springframework.boot</groupId>
@@ -107,11 +119,6 @@
                         <artifactId>spring-boot-starter-logging</artifactId> <!-- This is Logback -->
                     </exclusion>
                 </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-log4j2</artifactId> <!-- This enables Log4j2 -->
             </dependency>
 
             <!-- TEST -->

--- a/src/main/java/com/annepolis/lexiconmeum/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/exception/GlobalExceptionHandler.java
@@ -4,7 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.web.error.ErrorAttributeOptions;
-import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.boot.webmvc.error.ErrorAttributes;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;


### PR DESCRIPTION
### Summary of Changes
- Upgraded Spring Boot from version 3.5.8 to 4.0.6.
- Updated Log4j BOM from version 2.25.3 to 2.26.0.
- Removed unused dependency `spring-boot-starter-log4j2`.
- Modified `GlobalExceptionHandler` to align with updated Spring Boot `ErrorAttributes`.
- Added project-specific contribution guidelines in a new `CLAUDE.md` file.

### Checklist
- [ ] Changes have been tested for compatibility.
- [ ] Documentation has been updated where applicable.
- [ ] OpenAPI configurations have been verified.
- [ ] No breaking changes introduced to the existing flow or APIs.