### PR TITLE
fix: return 400 on malformed UUID in getLexeme endpoint

### DIFF
--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/LexemeDetailController.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/LexemeDetailController.java
@@ -45,7 +45,7 @@ class LexemeDetailController {
         @PathVariable UUID id,
         @RequestParam(name = "type", required = false) PartOfSpeech expectedType
 ) {
-    Lexeme lexeme = getLexeme(id);
+    Lexeme lexeme = findLexeme(id);
 
     if (expectedType != null && lexeme.getPartOfSpeech() != expectedType) {
         throw new LexemeTypeMismatchException("Expected " + expectedType + " but got " + lexeme.getPartOfSpeech(), lexeme.getId());
@@ -60,16 +60,15 @@ class LexemeDetailController {
         summary = "Get raw lexeme model by ID",
         description = "Returns the raw lexeme domain model as JSON. This endpoint is primarily intended for inspection, debugging, and comparison with the curated lexeme detail response, rather than for direct presentation in clients."
 )
-    Lexeme getLexeme(@RequestParam String lexemeId){
+    Lexeme getLexeme(@RequestParam UUID lexemeId){
         logger.debug("fetching lexeme: {}", lexemeId);
-        UUID uuid = UUID.fromString(lexemeId);
-        Lexeme lexeme = getLexeme(uuid);
+        Lexeme lexeme = findLexeme(lexemeId);
 
         jsonDTOLogger.logAsJson(lexeme);
         return lexeme;
     }
 
-    private Lexeme getLexeme(UUID lexemeId ){
+    private Lexeme findLexeme(UUID lexemeId ){
         return lexemeReader.getLexemeIfPresent(lexemeId)
                 .orElseThrow(() -> {
                     logger.warn("Lexeme not found: {}", lexemeId);


### PR DESCRIPTION
## Summary

- `getLexeme` was accepting `lexemeId` as a raw `String` and calling `UUID.fromString()` manually, which threw an unchecked `IllegalArgumentException` on bad input and returned a 500
- Changed the param type to `UUID` so Spring handles conversion and returns 400 Bad Request on malformed input
- Renamed the private `getLexeme(UUID)` helper to `findLexeme` to resolve the resulting signature conflict

An integration test for this case (`testInvalidLexemeIdFormatReturnsBadRequest`) already existed and now passes.

## Test plan

- [x] `LexemeDetailControllerIntegrationTest` — all 9 tests pass including the malformed UUID case

🤖 Generated with [Claude Code](https://claude.com/claude-code)