### PR TITLE
hotfix: v0.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.annepolis</groupId>
     <artifactId>lexiconmeum</artifactId>
-    <version>0.12.0</version>
+    <version>0.12.1</version>
     <name>lexiconmeum</name>
     <description>lexiconmeum</description>
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,12 @@ app:
 api:
   base-path: /api/v1
 
+springdoc:
+  swagger-ui:
+    path: /api/v1/swagger-ui
+  api-docs:
+    path: /api/v1/api-docs
+
 server:
   port: 8085
 


### PR DESCRIPTION
## Summary
- Bumps version to 0.12.1
- Configures springdoc Swagger UI and API docs paths under `/api/v1`

## Test plan
- [ ] `./mvnw test` passes
- [ ] Swagger UI accessible at `/api/v1/swagger-ui` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)