### PR TITLE
hotfix: v0.12.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ Or build and run the JAR:
 
 OpenAPI docs are generated at runtime:
 ```bash
-GET /v3/api-docs 
-GET /swagger-ui/index.html
+GET  /api/v1/api-docs 
+GET  /api/v1/swagger-ui/index.html
 ```
 ### Autocomplete
 ```bash

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -111,8 +111,8 @@ After deployment, verify:
 
 Useful checks:
 ```bash 
-GET /swagger-ui/index.html 
-GET /v3/api-docs 
+GET /api/v1/swagger-ui/index.html 
+GET /api/v1/api-docs 
 GET /api/v1/lexemes/autocomplete/prefix?prefix=am&limit=5
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.annepolis</groupId>
     <artifactId>lexiconmeum</artifactId>
-    <version>0.12.1</version>
+    <version>0.12.2</version>
     <name>lexiconmeum</name>
     <description>lexiconmeum</description>
 


### PR DESCRIPTION
## Summary
- Bumps version to 0.12.2 to cover docs update missed in v0.12.1

## Test plan
- [ ] `./mvnw test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)