### PR TITLE
Bump version to 0.12.3 and set forward headers strategy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.annepolis</groupId>
     <artifactId>lexiconmeum</artifactId>
-    <version>0.12.2</version>
+    <version>0.12.3</version>
     <name>lexiconmeum</name>
     <description>lexiconmeum</description>
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,7 @@ springdoc:
     path: /api/v1/api-docs
 
 server:
+  forward-headers-strategy: native
   port: 8085
 
 logging:


### PR DESCRIPTION
This pull request includes the following changes:
- Updated version to 0.12.3 in preparation for the new release.
- Configured the forward headers strategy so backend can handle swagger http requests

No additional issues were linked to this pull request.