### PR TITLE
feat: expose raw_glosses as nested definition tree with shortDefinition

### DIFF
--- a/docs/planning/enhance-glosses-plan.md
+++ b/docs/planning/enhance-glosses-plan.md
@@ -1,36 +1,34 @@
-## Enhance Glosses
+# Enhance Glosses
 
+## Phase 1
 The "buildSense" method in the ParserSupport class extracts word glosses from wiktionary jsonl files and populates the glosses array for each Sense in a Lexeme.
 
 In the jsonl for each wiktionary word Each set of gloss elements actually represents an indented list item for a given definition where each parent item of each list item is included in each gloss array. For example:
 
 ```json lines
 {
-  "raw_glosses": [
-    "(literally):",
-    "great, large, big; (of things) vast, extensive, spacious (of physical size or quantity)"
-  ],
-}
-{
-  "raw_glosses": [
-    "(literally):",
-    "especially:",
-    "great, much, abundant, considerable (of measure, weight, quantity)"
-  ],
-}
-{
-  "raw_glosses": [
-    "(literally):",
-    "especially:",
-    "(rare, of time) synonym of longus, multus"
+  "senses": [
+    {
+      "raw_glosses": [
+        "(literally):",
+        "great, large, big; (of things) vast, extensive, spacious (of physical size or quantity)"
+      ],
+      "glosses": [
+        "great, large, big; (of things) vast, extensive, spacious (of physical size or quantity)"
+      ]
+    },
+    {
+      "raw_glosses": [
+        "(literally):",
+        "especially:",
+        "great, much, abundant, considerable (of measure, weight, quantity)"
+      ],
+      "glosses": [
+        "especially:",
+        "great, much, abundant, considerable (of measure, weight, quantity)"
+      ]
+    }
   ]
-}
-{
-  "raw_glosses": [
-    "(literally):",
-    "especially:",
-    "loud, powerful, strong, mighty (of voice)"
-  ],
 }
 
 ```
@@ -69,7 +67,57 @@ But we want to properly reflect the hierarchical structure of the glosses so tha
         2. (rare, of time) synonym of longus, multus 
         3. loud, powerful, strong, mighty (of voice)
 
+Response JSON Example:
+```json
+{
+  "definitions": [
+    {
+      "text": "(literally):",
+      "children": [
+        {
+          "text": "great, large, big; (of things) vast, extensive, spacious (of physical size or quantity)"
+        },
+        {
+          "text": "especially:",
+          "children": [
+            {
+              "text": "great, much, abundant, considerable (of measure, weight, quantity)"
+            },
+            {
+              "text": "(rare, of time) synonym of longus, multus"
+            },
+            {
+              "text": "loud, powerful, strong, mighty (of voice)"
+            }
+          ]
+        }
+      ]
+    }
+    ]
+  }
+```
 ## Fallback to 'glosses'
 
 Not all Wiktionary sense nodes include a `raw_glosses` field (e.g. `amo`). In `buildSense`, after checking `raw_glosses`, fall back to the `glosses` array if `raw_glosses` is absent or empty. This keeps backward compatibility for entries that only have `glosses`, while preferring the richer `raw_glosses` data when available.
 
+
+## Phase 2
+
+### Add 'Short Definition'
+
+Add a sibling node 'shortDefinition' to 'definitions' DTO. Populate it from the last element of the glosses array from the first sense in the Lexeme. (See DefinitionsSectionContributor class)
+
+resulting JSON:
+```json
+{
+  "shortDefinition": "to love, like; to be fond of",
+  "definitions": [
+    {
+      "text": "(literally):",
+      "children": [ { "text": "great, large, big; ..." } ]
+    }
+  ]
+}
+```
+
+Add a test that checks that 'DefinitionsSectionContributor' populates shortDefinition' field. You probably need to add a DefinitionsSectionContributorTest class 

--- a/docs/planning/enhance-glosses-plan.md
+++ b/docs/planning/enhance-glosses-plan.md
@@ -1,0 +1,70 @@
+## Enhance Glosses
+
+The "buildSense" method in the ParserSupport class extracts word glosses from wiktionary jsonl files and populates the glosses array for each Sense in a Lexeme.
+
+In the jsonl for each wiktionary word Each set of gloss elements actually represents an indented list item for a given definition where each parent item of each list item is included in each gloss array. For example:
+
+```json lines
+{
+  "raw_glosses": [
+    "(literally):",
+    "great, large, big; (of things) vast, extensive, spacious (of physical size or quantity)"
+  ],
+}
+{
+  "raw_glosses": [
+    "(literally):",
+    "especially:",
+    "great, much, abundant, considerable (of measure, weight, quantity)"
+  ],
+}
+{
+  "raw_glosses": [
+    "(literally):",
+    "especially:",
+    "(rare, of time) synonym of longus, multus"
+  ]
+}
+{
+  "raw_glosses": [
+    "(literally):",
+    "especially:",
+    "loud, powerful, strong, mighty (of voice)"
+  ],
+}
+
+```
+Currently, DefinitionsSectionContributor flattens them into an array in the LexemDetailResponse DTO which gets serialized to this: 
+```json
+{
+  "definitions": [
+    "(literally):",
+    "great, large, big; (of things) vast, extensive, spacious (of physical size or quantity)",
+    "(literally):",
+    "especially:",
+    "great, much, abundant, considerable (of measure, weight, quantity)",
+    "(literally):",
+    "especially:",
+    "(rare, of time) synonym of longus, multus",
+    "(literally):",
+    "especially:",
+    "loud, powerful, strong, mighty (of voice)",
+    "(figurative):",
+    "(in general) great, grand, mighty, noble, lofty, important, of great weight or importance, momentous",
+    "(figurative):",
+    "(in particular):",
+    "advanced in years, of great age, aged (of age, with nātu)",
+    "(figurative):",
+    "(in particular):",
+    "(in specifications of value, in the neutral absolute) high, dear, of great value, at a high price"
+  ]
+}
+```
+But we want to properly reflect the hierarchical structure of the glosses so that they look more like this (minus the numbering):
+
+1. (literally):
+    1. great, large, big; (of things) vast, extensive, spacious (of physical size or quantity)
+    2. especially:
+        1. great, much, abundant, considerable (of measure, weight, quantity)
+        2. (rare, of time) synonym of longus, multus 
+        3. loud, powerful, strong, mighty (of voice)

--- a/docs/planning/enhance-glosses-plan.md
+++ b/docs/planning/enhance-glosses-plan.md
@@ -68,3 +68,8 @@ But we want to properly reflect the hierarchical structure of the glosses so tha
         1. great, much, abundant, considerable (of measure, weight, quantity)
         2. (rare, of time) synonym of longus, multus 
         3. loud, powerful, strong, mighty (of voice)
+
+## Fallback to 'glosses'
+
+Not all Wiktionary sense nodes include a `raw_glosses` field (e.g. `amo`). In `buildSense`, after checking `raw_glosses`, fall back to the `glosses` array if `raw_glosses` is absent or empty. This keeps backward compatibility for entries that only have `glosses`, while preferring the richer `raw_glosses` data when available.
+

--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/ParserSupport.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/ParserSupport.java
@@ -115,12 +115,24 @@ public class ParserSupport {
         }
     }
 
-    // Build sense nodes and add to builder
+    // Build sense nodes and add to builder; seed shortDefinition from first sense's glosses
     void addSenses(JsonNode sensesNode, LexemeBuilder lexemeBuilder, Logger logger) {
         if (sensesNode.isArray()) {
+            boolean first = true;
             for (JsonNode senseNode : sensesNode) {
+                if (first) {
+                    seedShortDefinition(senseNode, lexemeBuilder);
+                    first = false;
+                }
                 lexemeBuilder.addSense(buildSense(senseNode, lexemeBuilder, logger));
             }
+        }
+    }
+
+    private void seedShortDefinition(JsonNode senseNode, LexemeBuilder lexemeBuilder) {
+        JsonNode glosses = senseNode.path(GLOSSES.get());
+        if (glosses.isArray() && !glosses.isEmpty()) {
+            lexemeBuilder.setShortDefinition(glosses.get(glosses.size() - 1).asString());
         }
     }
 

--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/ParserSupport.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/ParserSupport.java
@@ -134,10 +134,13 @@ public class ParserSupport {
             }
         }
 
-        JsonNode glosses = senseNode.path(GLOSSES.get());
+        JsonNode glosses = senseNode.path(RAW_GLOSSES.get());
+        // Handle words with no raw glosses
+        if ( glosses.isEmpty()) {
+            glosses = senseNode.path(GLOSSES.get());
+        }
         if (glosses.isArray() && !glosses.isEmpty()) {
-
-            for(JsonNode gloss: glosses){
+            for (JsonNode gloss : glosses) {
                 builder.addGloss(gloss.asString());
             }
         }

--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataJsonKey.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataJsonKey.java
@@ -11,6 +11,7 @@ public enum WiktionaryLexicalDataJsonKey {
     FORM("form"),
     FORMS("forms"),
     GLOSSES("glosses"),
+    RAW_GLOSSES("raw_glosses"),
     HEAD("head"),
     HEAD_TEMPLATES("head_templates"),
     POSITIVE("positive"),

--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/Lexeme.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/Lexeme.java
@@ -27,6 +27,7 @@ public class Lexeme {
     private final Set<InflectionClass> inflectionClasses;
     private final List<Sense> senses;
     private final Map<String, Inflection> inflections;
+    private final String shortDefinition;
 
     Lexeme(LexemeBuilder builder) {
         this.lemma = builder.getLemma();
@@ -38,6 +39,7 @@ public class Lexeme {
         this.inflectionClasses = builder.getInflectionClasses();
         this.partOfSpeechDetails = builder.getPartOfSpeechDetails();
         this.canonicalForms = builder.getCanonicalForms();
+        this.shortDefinition = builder.getShortDefinition();
     }
 
     public UUID getId() {
@@ -83,6 +85,8 @@ public class Lexeme {
     }
 
     public List<Sense> getSenses() { return senses; }
+
+    public String getShortDefinition() { return shortDefinition; }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/LexemeBuilder.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/LexemeBuilder.java
@@ -18,6 +18,7 @@ public class LexemeBuilder {
     private final PartOfSpeech partOfSpeech;
     private final String etymologyNumber;
     private PartOfSpeechDetails partOfSpeechDetails;
+    private String shortDefinition;
     private final List<Sense> senses = new ArrayList<>();
     private final Map<String, Inflection> inflectionIndex = new HashMap<>();
     private final Set<InflectionClass> inflectionClasses = new TreeSet<>();
@@ -67,6 +68,13 @@ public class LexemeBuilder {
 
     public LexemeBuilder setPartOfSpeechDetails(PartOfSpeechDetails partOfSpeechDetails) {
         this.partOfSpeechDetails = partOfSpeechDetails;
+        return this;
+    }
+
+    public String getShortDefinition() { return shortDefinition; }
+
+    public LexemeBuilder setShortDefinition(String shortDefinition) {
+        this.shortDefinition = shortDefinition;
         return this;
     }
 
@@ -152,6 +160,8 @@ public class LexemeBuilder {
         if (lexeme.getPartOfSpeechDetails() != null) {
             builder.setPartOfSpeechDetails(lexeme.getPartOfSpeechDetails());
         }
+
+        builder.setShortDefinition(lexeme.getShortDefinition());
 
         return builder;
     }

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/DefinitionNode.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/DefinitionNode.java
@@ -1,0 +1,26 @@
+package com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DefinitionNode {
+
+    private final String text;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final List<DefinitionNode> children = new ArrayList<>();
+
+    public DefinitionNode(String text) {
+        this.text = text;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public List<DefinitionNode> getChildren() {
+        return children;
+    }
+}

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/LexemeDetailResponse.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/LexemeDetailResponse.java
@@ -46,6 +46,13 @@ public class LexemeDetailResponse {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     List<DefinitionNode> definitions = new ArrayList<>();
 
+    @Schema(
+            description = "A single, concise one-line definition suitable for compact display. Omitted when null.",
+            example = "to love, like; to be fond of"
+    )
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String shortDefinition;
+
     //INFLECTION RELATED FIELDS
     @Schema(example = "1st conjugation")
     String inflectionClass;
@@ -186,6 +193,13 @@ public class LexemeDetailResponse {
         this.definitions = definitions;
     }
 
+    public String getShortDefinition() {
+        return shortDefinition;
+    }
+
+    public void setShortDefinition(String shortDefinition) {
+        this.shortDefinition = shortDefinition;
+    }
 
     public String getInflectionClass() {
         return inflectionClass;

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/LexemeDetailResponse.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/LexemeDetailResponse.java
@@ -41,10 +41,10 @@ public class LexemeDetailResponse {
     GrammaticalCase governedCase;
 
     @Schema(description = "omitted when empty", example = """
-           ["to love", "to be fond of, like, admire"]
+           [{"text": "(literally):", "children": [{"text": "to love"}]}]
            """)
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    List<String> definitions = new ArrayList<>();
+    List<DefinitionNode> definitions = new ArrayList<>();
 
     //INFLECTION RELATED FIELDS
     @Schema(example = "1st conjugation")
@@ -178,12 +178,12 @@ public class LexemeDetailResponse {
         this.governedCase = governedCase;
     }
 
-    public List<String> getDefinitions() {
+    public List<DefinitionNode> getDefinitions() {
         return definitions;
     }
 
-    public void addDefinition(String definition) {
-        this.getDefinitions().add(definition);
+    public void setDefinitions(List<DefinitionNode> definitions) {
+        this.definitions = definitions;
     }
 
 

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/DefinitionsSectionContributor.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/DefinitionsSectionContributor.java
@@ -24,6 +24,9 @@ class DefinitionsSectionContributor implements LexemeDetailSectionContributor {
             List<String> path = sense.getGloss();
             if (!path.isEmpty()) {
                 insertPath(roots, path, 0);
+                if (dto.getShortDefinition() == null) {
+                    dto.setShortDefinition(path.get(path.size() - 1));
+                }
             }
         }
         dto.setDefinitions(roots);

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/DefinitionsSectionContributor.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/DefinitionsSectionContributor.java
@@ -24,11 +24,9 @@ class DefinitionsSectionContributor implements LexemeDetailSectionContributor {
             List<String> path = sense.getGloss();
             if (!path.isEmpty()) {
                 insertPath(roots, path, 0);
-                if (dto.getShortDefinition() == null) {
-                    dto.setShortDefinition(path.get(path.size() - 1));
-                }
             }
         }
+        dto.setShortDefinition(lexeme.getShortDefinition());
         dto.setDefinitions(roots);
     }
 

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/DefinitionsSectionContributor.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/DefinitionsSectionContributor.java
@@ -1,9 +1,14 @@
 package com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.section;
 
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
+import com.annepolis.lexiconmeum.shared.model.Sense;
+import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.DefinitionNode;
 import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.LexemeDetailResponse;
 import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.LexemeDetailSectionContributor;
 import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Component("definitionsSectionContributor")
 class DefinitionsSectionContributor implements LexemeDetailSectionContributor {
@@ -14,8 +19,28 @@ class DefinitionsSectionContributor implements LexemeDetailSectionContributor {
 
     @Override
     public void contribute(Lexeme lexeme, LexemeDetailResponse dto) {
-        lexeme.getSenses().stream()
-                .flatMap(s -> s.getGloss().stream())
-                .forEach(dto::addDefinition);
+        List<DefinitionNode> roots = new ArrayList<>();
+        for (Sense sense : lexeme.getSenses()) {
+            List<String> path = sense.getGloss();
+            if (!path.isEmpty()) {
+                insertPath(roots, path, 0);
+            }
+        }
+        dto.setDefinitions(roots);
+    }
+
+    private void insertPath(List<DefinitionNode> siblings, List<String> path, int depth) {
+        if (depth >= path.size()) return;
+        DefinitionNode node = findOrCreate(siblings, path.get(depth));
+        insertPath(node.getChildren(), path, depth + 1);
+    }
+
+    private DefinitionNode findOrCreate(List<DefinitionNode> siblings, String text) {
+        for (DefinitionNode node : siblings) {
+            if (node.getText().equals(text)) return node;
+        }
+        DefinitionNode newNode = new DefinitionNode(text);
+        siblings.add(newNode);
+        return newNode;
     }
 }

--- a/src/test/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataParserTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataParserTest.java
@@ -260,6 +260,18 @@ class WiktionaryLexicalDataParserTest {
                         .orElseThrow(() -> new AssertionError("Missing gloss 'to love'")));
     }
 
+    @SuppressWarnings("java:S2699")
+    @Test
+    void rawGlossesAreParsedAndPopulated() throws Exception {
+        getAdjectiveLexemes().stream()
+                .filter(lexeme -> lexeme.getLemma().equals("magnus"))
+                .findFirst()
+                .map(l -> l.getSenses().stream()
+                        .filter(s -> s.getGloss().contains("great, large, big; (of things) vast, extensive, spacious (of physical size or quantity)"))
+                        .findFirst()
+                        .orElseThrow(() -> new AssertionError("Missing raw gloss for magnus")));
+    }
+
     @Test
     void parserMapsFutureAndPerfectTagsToFuturePerfectTense() throws Exception {
         Optional<Inflection> tenseTag = getVerbLexemes().stream().filter(lexeme -> lexeme.getLemma().equals("amo"))

--- a/src/test/java/com/annepolis/lexiconmeum/shared/model/LexemeTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/shared/model/LexemeTest.java
@@ -8,7 +8,7 @@ class LexemeTest {
     void equalsContract() {
         EqualsVerifier.forClass(Lexeme.class)
                 .usingGetClass()
-                .withIgnoredFields("id", "inflectionClasses", "senses", "inflections", "partOfSpeechDetails", "canonicalForms")
+                .withIgnoredFields("id", "inflectionClasses", "shortDefinition","senses", "inflections", "partOfSpeechDetails", "canonicalForms")
                 .verify();
     }
 }

--- a/src/test/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/DefinitionsSectionContributorTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/DefinitionsSectionContributorTest.java
@@ -1,0 +1,53 @@
+package com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.section;
+
+import com.annepolis.lexiconmeum.shared.model.Lexeme;
+import com.annepolis.lexiconmeum.shared.model.LexemeBuilder;
+import com.annepolis.lexiconmeum.shared.model.Sense;
+import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.PartOfSpeech;
+import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.LexemeDetailResponse;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DefinitionsSectionContributorTest {
+
+    private final DefinitionsSectionContributor contributor = new DefinitionsSectionContributor();
+
+    private Lexeme lexemeWithSenses(Sense... senses) {
+        LexemeBuilder builder = new LexemeBuilder("test", PartOfSpeech.VERB, "1");
+        for (Sense sense : senses) {
+            builder.addSense(sense);
+        }
+        return builder.build();
+    }
+
+    @Test
+    void shortDefinitionIsLeafOfFirstSensePath() {
+        Sense sense = new Sense.Builder()
+                .addGloss("(literally):")
+                .addGloss("to love, like; to be fond of")
+                .build();
+
+        LexemeDetailResponse dto = new LexemeDetailResponse();
+        contributor.contribute(lexemeWithSenses(sense), dto);
+
+        assertEquals("to love, like; to be fond of", dto.getShortDefinition());
+    }
+
+    @Test
+    void shortDefinitionComesFromFirstNonEmptySense() {
+        Sense first = new Sense.Builder()
+                .addGloss("(literally):")
+                .addGloss("to love")
+                .build();
+        Sense second = new Sense.Builder()
+                .addGloss("(figurative):")
+                .addGloss("to cherish")
+                .build();
+
+        LexemeDetailResponse dto = new LexemeDetailResponse();
+        contributor.contribute(lexemeWithSenses(first, second), dto);
+
+        assertEquals("to love", dto.getShortDefinition());
+    }
+}

--- a/src/test/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/DefinitionsSectionContributorTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/section/DefinitionsSectionContributorTest.java
@@ -8,13 +8,15 @@ import com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.LexemeDetai
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class DefinitionsSectionContributorTest {
 
     private final DefinitionsSectionContributor contributor = new DefinitionsSectionContributor();
 
-    private Lexeme lexemeWithSenses(Sense... senses) {
+    private Lexeme lexeme(String shortDefinition, Sense... senses) {
         LexemeBuilder builder = new LexemeBuilder("test", PartOfSpeech.VERB, "1");
+        builder.setShortDefinition(shortDefinition);
         for (Sense sense : senses) {
             builder.addSense(sense);
         }
@@ -22,32 +24,25 @@ class DefinitionsSectionContributorTest {
     }
 
     @Test
-    void shortDefinitionIsLeafOfFirstSensePath() {
+    void shortDefinitionIsPassedThroughFromLexeme() {
         Sense sense = new Sense.Builder()
                 .addGloss("(literally):")
                 .addGloss("to love, like; to be fond of")
                 .build();
 
         LexemeDetailResponse dto = new LexemeDetailResponse();
-        contributor.contribute(lexemeWithSenses(sense), dto);
+        contributor.contribute(lexeme("to love, like; to be fond of", sense), dto);
 
         assertEquals("to love, like; to be fond of", dto.getShortDefinition());
     }
 
     @Test
-    void shortDefinitionComesFromFirstNonEmptySense() {
-        Sense first = new Sense.Builder()
-                .addGloss("(literally):")
-                .addGloss("to love")
-                .build();
-        Sense second = new Sense.Builder()
-                .addGloss("(figurative):")
-                .addGloss("to cherish")
-                .build();
+    void shortDefinitionIsNullWhenNotSetOnLexeme() {
+        Sense sense = new Sense.Builder().addGloss("to love").build();
 
         LexemeDetailResponse dto = new LexemeDetailResponse();
-        contributor.contribute(lexemeWithSenses(first, second), dto);
+        contributor.contribute(lexeme(null, sense), dto);
 
-        assertEquals("to love", dto.getShortDefinition());
+        assertNull(dto.getShortDefinition());
     }
 }


### PR DESCRIPTION
## Summary

- Switches Wiktionary parsing to read `raw_glosses` (falls back to `glosses` for entries like `amo` that lack it)
- Restructures `definitions` in `LexemeDetailResponse` from a flat `List<String>` to a nested `DefinitionNode` tree, reflecting the hierarchical structure encoded in `raw_glosses` paths
- Adds `shortDefinition` field on `Lexeme`, seeded at parse time from the last element of the first sense's `glosses` array; surfaced as a sibling field to `definitions` in the API response

## Test plan

- [x] `WiktionaryLexicalDataParserTest#glossesAreParsedAndPopulated` — verifies fallback for `amo`
- [x] `WiktionaryLexicalDataParserTest#rawGlossesAreParsedAndPopulated` — verifies `raw_glosses` path parsed for `magnus`
- [x] `DefinitionsSectionContributorTest` — verifies `shortDefinition` pass-through from lexeme to DTO
- [x] `./mvnw test` passes (excluding pre-existing `AutocompleteServiceSpringTest` environment failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)