### PR TITLE
chore: v14 Sonar cleanup

### DIFF
--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/DataLinkingService.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/DataLinkingService.java
@@ -137,34 +137,38 @@ public class DataLinkingService {
      */
     private void addGenderedCompoundForms(StagedLexemeCache stagedLexemeCache) {
         for (Lexeme lexeme : stagedLexemeCache.getStagedLexemes()) {
-            if (!(lexeme.getPartOfSpeechDetails() instanceof VerbDetails verbDetails)) {
-                continue;
-            }
-
-            List<Conjugation> genderedForms = new ArrayList<>();
-            for (ParticipleDeclensionSet participleSet : verbDetails.getParticiples().values()) {
-                if (participleSet.getTense() == GrammaticalTense.PERFECT) {
-                    genderedForms.addAll(compoundInflectionGenerator.generateAllGenderedCompoundForms(participleSet));
-                }
-            }
-            if (genderedForms.isEmpty()) {
-                continue;
-            }
-
-            LexemeBuilder builder = LexemeBuilder.fromLexeme(lexeme);
-            for (Conjugation genderedForm : genderedForms) {
-                // Drop the ungendered baseline this gendered form supersedes; the
-                // parse-time baseline reused the singular participle base for plurals.
-                builder.removeInflection(InflectionKey.joinConjugationParts(
-                        genderedForm.getVoice(),
-                        genderedForm.getMood(),
-                        genderedForm.getTense(),
-                        genderedForm.getPerson(),
-                        genderedForm.getNumber()));
-                builder.addInflection(genderedForm);
-            }
-            stagedLexemeCache.replaceLexeme(lexeme, builder.build());
+            enrichVerbWithGenderedCompoundForms(lexeme, stagedLexemeCache);
         }
+    }
+
+    private void enrichVerbWithGenderedCompoundForms(Lexeme lexeme, StagedLexemeCache stagedLexemeCache) {
+        if (!(lexeme.getPartOfSpeechDetails() instanceof VerbDetails verbDetails)) {
+            return;
+        }
+
+        List<Conjugation> genderedForms = new ArrayList<>();
+        for (ParticipleDeclensionSet participleSet : verbDetails.getParticiples().values()) {
+            if (participleSet.getTense() == GrammaticalTense.PERFECT) {
+                genderedForms.addAll(compoundInflectionGenerator.generateAllGenderedCompoundForms(participleSet));
+            }
+        }
+        if (genderedForms.isEmpty()) {
+            return;
+        }
+
+        LexemeBuilder builder = LexemeBuilder.fromLexeme(lexeme);
+        for (Conjugation genderedForm : genderedForms) {
+            // Drop the ungendered baseline this gendered form supersedes; the
+            // parse-time baseline reused the singular participle base for plurals.
+            builder.removeInflection(InflectionKey.joinConjugationParts(
+                    genderedForm.getVoice(),
+                    genderedForm.getMood(),
+                    genderedForm.getTense(),
+                    genderedForm.getPerson(),
+                    genderedForm.getNumber()));
+            builder.addInflection(genderedForm);
+        }
+        stagedLexemeCache.replaceLexeme(lexeme, builder.build());
     }
 
     private Optional<Lexeme> findMatchingLexeme(String parentLemma, LinkableData dataToLink, StagedLexemeCache stagedLexemeCache) {

--- a/src/test/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataParserTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataParserTest.java
@@ -320,7 +320,7 @@ class WiktionaryLexicalDataParserTest {
         assertTrue(brevis.isPresent(), "Brevis lexeme not found");
         assertEquals(Set.of(THIRD), brevis.get().getInflectionClasses());
 
-        brevis.get().getInflections().stream()
+        brevis.get().getInflections()
                 .forEach(i -> {
                     if (i instanceof Agreement ag) {
                         assert ag.getNumber() != null : "GrammaticalNumber is null in Agreement: " + ag;

--- a/src/test/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ParticipleTableMapperTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ParticipleTableMapperTest.java
@@ -72,7 +72,7 @@ class ParticipleTableMapperTest {
         return lexemeBuilder.setPartOfSpeechDetails(verbDetailsBuilder.build()).build();
     }
 
-    private JsonNode loadTestParticiplesJsonRoot() throws IOException {
+    private JsonNode loadTestParticiplesJsonRoot() {
 
         ObjectMapper mapper = new ObjectMapper();
         InputStream is = getClass().getClassLoader().getResourceAsStream("participles.json");

--- a/src/test/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/TextSearchControllerIntegrationTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/webapi/bff/textsearch/TextSearchControllerIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.annepolis.lexiconmeum.webapi.bff.textsearch;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
@@ -69,7 +68,7 @@ class TextSearchControllerIntegrationTest {
     }
 
     @Test
-    void testTextSuggestionResultClientLimit() throws JsonProcessingException {
+    void testTextSuggestionResultClientLimit() {
         String url = getFullBaseUrl() + PREFIX + "?prefix=ama" + "&limit=12";
 
         ResponseEntity<String> response = restClient.get().uri(url).retrieve().toEntity(String.class);
@@ -84,7 +83,7 @@ class TextSearchControllerIntegrationTest {
     }
 
     @Test
-    void testTextSuggestionResultClientLimitMax() throws JsonProcessingException {
+    void testTextSuggestionResultClientLimitMax() {
         String url = getFullBaseUrl() + PREFIX + "?prefix=ama" + "&limit=100";
 
         ResponseEntity<String> response = restClient.get().uri(url).retrieve().toEntity(String.class);
@@ -99,7 +98,7 @@ class TextSearchControllerIntegrationTest {
     }
 
     @Test
-    void testTextSuggestionResultLimitDefault() throws JsonProcessingException {
+    void testTextSuggestionResultLimitDefault() {
         String url = getFullBaseUrl() + PREFIX + "?prefix=am";
 
         ResponseEntity<String> response = restClient.get().uri(url).retrieve().toEntity(String.class);


### PR DESCRIPTION
## Summary
Small Sonar-driven cleanups on the v14 code, no behavior change.

- **DataLinkingService** — extract the per-verb body of `addGenderedCompoundForms` into a helper so the loop's guard clauses become early returns, clearing `java:S135` (at most one `break`/`continue` per loop).
- **Tests** — drop a redundant `.stream()` before `forEach`, and remove unused `throws` clauses and an unused `JsonProcessingException` import.

## Testing
Affected classes pass; changes are refactors/lint only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)