### PR TITLE
Add supine forms to verb detail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Prefer the Maven wrapper over a system Maven install.
 
 ## Architecture Pointers
 
-- Architecture and module responsibilities: `ARCHITECTURE.md`
+- Architecture and module responsibilities: `docs/ARCHITECTURE.md`
 - Public context, endpoint examples, deployment notes: `README.md`
 - Planned direction: `ROADMAP.md`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,13 @@ Add focused tests when behavior changes.
 
 Do not add tests for documentation-only changes unless explicitly asked.
 
+## Git Workflow
+
+- `develop` is the default branch.
+- Create feature branches from `develop`; feature-branch PRs target `develop` only.
+- Only release branches may open PRs against `master`.
+- Merging to `master` deploys to production.
+
 ## Data And Fixtures
 
 The JSONL files under `src/main/resources` and `src/test/resources` are lexical data inputs and fixtures. Keep changes to them intentional and small. When changing parser behavior, prefer adding or editing the smallest relevant test fixture instead of broad data churn.

--- a/docs/planning/add-supine-tense.md
+++ b/docs/planning/add-supine-tense.md
@@ -1,0 +1,53 @@
+# Add Supine Tense
+
+## Goal
+
+Ingest Wiktionary verb forms tagged `supine`, show them in `LEXEME_DETAIL` after existing participle tenses, and make them available to PREFIX and SUFFIX search.
+
+## Current State
+
+- Supines occur on verb `forms` entries, normally with `supine`, `noun-from-verb`, and an accusative or ablative tag.
+- `POSVerbParser` sends these entries through the normal conjugation path, but `supine` has no tag mapping. `Conjugation.Builder` therefore has no required tense and rejects the form.
+- `SearchableVerbFormsExtractor` already indexes all accepted verb inflections, so no new search-index path should be needed once supines are retained.
+- `POSParticipleParser` already maps case tags into `Participle` objects and packages them in `ParticipleDeclensionSet`s, which `VerbDetails` stores.
+- Supines are non-gendered and originate in the parent verb's `forms` array, so they should use that same model path directly, without `StagedParticipleData` or a second JSON entry.
+- `ParticipleTableMapper` currently assumes gendered declension sets. It needs an explicit supine response path rather than treating the two supine cases as a gendered participle table.
+
+## Phase 1: Model And Tag Mapping
+
+1. Add `SUPINE` to `GrammaticalTense` and `GrammaticalParticipleTense`, ordered after existing values and named `Supine` in the API.
+2. Extend the existing `ParticipleDeclensionSet` construction path to represent a supine explicitly, without inventing a grammatical voice. The set key must remain stable and distinct from ordinary participles.
+3. Reuse the existing `Participle.Builder` case-tag mapping for supine forms. Extract only the small common form-building helper from `POSParticipleParser` if needed; do not duplicate or generalize the staging process.
+
+Acceptance: an accusative/ablative supine can be represented in one `ParticipleDeclensionSet` with its case and form intact, and the set is distinguishable from normal participles.
+
+## Phase 2: Ingestion Coverage
+
+1. In `POSVerbParser`, split valid verb forms by tag: retain ordinary forms on the current conjugation path; collect `supine` forms as `Participle` objects using the shared form-building logic.
+2. Build the supine `ParticipleDeclensionSet` during parent-verb parsing and add it directly to the verb's `VerbDetails.Builder`. Do not create or stage `StagedParticipleData`.
+3. Preserve any pre-existing `VerbDetails` when attaching the set, following the rebuild pattern in `StagedParticipleData.link()`.
+4. Add focused `POSVerbParser` coverage using existing fixture data (`sequor` contains accusative and ablative supines, including alternatives), plus parser integration coverage for direct attachment.
+
+Acceptance: `secūtum`/`sequūtum` and `secūtū`/`sequūtū` are retained under `VerbDetails` for `sequor`; no staging/linking or compound-tense behavior changes.
+
+## Phase 3: Lexeme-Detail Mapping
+
+1. Extend the participle response DTO only as needed to represent a non-gendered supine entry with case-to-form values; do not fabricate gender, number, or a full participle declension grid.
+2. Extend `ParticipleTableMapper` to recognize the direct supine set in `VerbDetails`, map its accusative and ablative forms, and append `Supine` after the normal participle tenses.
+3. Keep `ConjugationTableMapper` unchanged: supines never enter the conjugation collection.
+4. Add mapper tests for name, order, accusative and ablative forms, and alternate-form behavior; add controller/integration coverage for the JSON shape.
+
+Acceptance: `LEXEME_DETAIL` exposes one `Supine` entry after existing participle tenses, with its actual case forms and no invented gender/number data.
+
+## Phase 4: Search And Regression Verification
+
+1. Add focused autocomplete/index tests proving a supine is found by both PREFIX and SUFFIX routes.
+2. Run focused parser, mapper, and text-search tests; then run `./mvnw test`.
+3. Verify the bundled lexical fixture needs no mass change; use existing `sequor` data unless a minimal dedicated fixture is required.
+
+Acceptance: supines are searchable by prefix and suffix, and all tests pass.
+
+## Scope
+
+- No parser rewrite, new index type, staging change, or bundled-data reformatting.
+- No change to normal participle linking or compound-tense generation.

--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/POSVerbParser.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/POSVerbParser.java
@@ -4,8 +4,11 @@ import com.annepolis.lexiconmeum.shared.model.Lexeme;
 import com.annepolis.lexiconmeum.shared.model.LexemeBuilder;
 import com.annepolis.lexiconmeum.shared.model.grammar.*;
 import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.PartOfSpeech;
+import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.ParticipleDeclensionSet;
+import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.VerbDetails;
 import com.annepolis.lexiconmeum.shared.model.inflection.Conjugation;
 import com.annepolis.lexiconmeum.shared.model.inflection.InflectionKey;
+import com.annepolis.lexiconmeum.shared.model.inflection.Participle;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -26,6 +29,8 @@ public class POSVerbParser implements PartOfSpeechParser {
     private static final Set<String> TAG_BLACKLIST = Set.of(
             "sigmatic"
     );
+
+    private static final String SUPINE_TAG = "supine";
 
     private static final Set<String> COMPOUND_TENSE_KEY_LIST = Set.of(
             "ACTIVE|INDICATIVE|PERFECT",
@@ -74,12 +79,19 @@ public class POSVerbParser implements PartOfSpeechParser {
     }
 
     public void addInflections(LexemeBuilder lexemeBuilder, JsonNode formsNode) {
+        List<Participle> supines = new ArrayList<>();
+
         for (JsonNode formNode : formsNode) {
             try {
                 if (parserSupport.isValidFormNode(formNode, PartOfSpeech.VERB.getInflectionTypeLower())) {
                    
                     String formValue = formNode.path(FORM.get()).asString();
                     List<String> tags = collectTags(formNode);
+
+                    if (isSupine(tags)) {
+                        supines.add(buildParticiple(formValue, tags));
+                        continue;
+                    }
 
                     Optional<Conjugation> optionalConjugation = buildConjugation(formValue, tags);
                     addInflection(lexemeBuilder, optionalConjugation);
@@ -92,6 +104,43 @@ public class POSVerbParser implements PartOfSpeechParser {
                 logger.trace(ParserSupport.LogMsg.SKIPPING_INVALID_FORM, ex.getMessage());
             }
         }
+
+        addSupineSet(lexemeBuilder, buildSupineSet(supines, lexemeBuilder.getLemma()));
+    }
+
+    Optional<ParticipleDeclensionSet> buildSupineSet(List<Participle> supines, String verbLemma) {
+        if (supines.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(ParticipleDeclensionSet.Builder.forSupine(verbLemma)
+                .addInflections(supines)
+                .build());
+    }
+
+    private void addSupineSet(LexemeBuilder lexemeBuilder, Optional<ParticipleDeclensionSet> supineSet) {
+        if (supineSet.isEmpty()) {
+            return;
+        }
+
+        VerbDetails.Builder detailsBuilder = getVerbDetailsBuilder(lexemeBuilder);
+        detailsBuilder.addParticipleSet(supineSet.get());
+        lexemeBuilder.setPartOfSpeechDetails(detailsBuilder.build());
+    }
+
+    private VerbDetails.Builder getVerbDetailsBuilder(LexemeBuilder lexemeBuilder) {
+        if (lexemeBuilder.getPartOfSpeechDetails() instanceof VerbDetails details) {
+            return details.toBuilder();
+        }
+        return new VerbDetails.Builder();
+    }
+
+    private Participle buildParticiple(String formValue, List<String> tags) {
+        Participle.Builder builder = new Participle.Builder(normalizeFormValue(formValue));
+        for (String tag : tags) {
+            parserSupport.applyToInflection(builder, tag, logger);
+        }
+        return builder.build();
     }
 
 
@@ -161,6 +210,10 @@ public class POSVerbParser implements PartOfSpeechParser {
             }
         }
         return false;
+    }
+
+    private boolean isSupine(List<String> tags) {
+        return tags.contains(SUPINE_TAG);
     }
 
     private List<String> collectTags(JsonNode formNode) {

--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/POSVerbParser.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/POSVerbParser.java
@@ -2,7 +2,10 @@ package com.annepolis.lexiconmeum.ingest.wiktionary;
 
 import com.annepolis.lexiconmeum.shared.model.Lexeme;
 import com.annepolis.lexiconmeum.shared.model.LexemeBuilder;
-import com.annepolis.lexiconmeum.shared.model.grammar.*;
+import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalGender;
+import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalParticipleTense;
+import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalTense;
+import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalVoice;
 import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.PartOfSpeech;
 import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.ParticipleDeclensionSet;
 import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.VerbDetails;
@@ -21,16 +24,16 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.annepolis.lexiconmeum.ingest.wiktionary.WiktionaryLexicalDataJsonKey.*;
+import static com.annepolis.lexiconmeum.ingest.wiktionary.WiktionaryLexicalDataKeyWord.SIGMATIC;
+import static com.annepolis.lexiconmeum.ingest.wiktionary.WiktionaryLexicalDataKeyWord.SUPINE;
 
 @Component
 public class POSVerbParser implements PartOfSpeechParser {
     static final Logger logger = LogManager.getLogger(POSVerbParser.class);
 
     private static final Set<String> TAG_BLACKLIST = Set.of(
-            "sigmatic"
+            SIGMATIC.get()
     );
-
-    private static final String SUPINE_TAG = "supine";
 
     private static final Set<String> COMPOUND_TENSE_KEY_LIST = Set.of(
             "ACTIVE|INDICATIVE|PERFECT",
@@ -79,7 +82,7 @@ public class POSVerbParser implements PartOfSpeechParser {
     }
 
     public void addInflections(LexemeBuilder lexemeBuilder, JsonNode formsNode) {
-        List<Participle> supines = new ArrayList<>();
+        List<Participle> supineInflections = new ArrayList<>();
 
         for (JsonNode formNode : formsNode) {
             try {
@@ -89,7 +92,7 @@ public class POSVerbParser implements PartOfSpeechParser {
                     List<String> tags = collectTags(formNode);
 
                     if (isSupine(tags)) {
-                        supines.add(buildParticiple(formValue, tags));
+                        supineInflections.add(buildSupineInflection(formValue, tags));
                         continue;
                     }
 
@@ -105,44 +108,8 @@ public class POSVerbParser implements PartOfSpeechParser {
             }
         }
 
-        addSupineSet(lexemeBuilder, buildSupineSet(supines, lexemeBuilder.getLemma()));
+        addParticipleDeclensionSet(lexemeBuilder, supineInflections);
     }
-
-    Optional<ParticipleDeclensionSet> buildSupineSet(List<Participle> supines, String verbLemma) {
-        if (supines.isEmpty()) {
-            return Optional.empty();
-        }
-
-        return Optional.of(ParticipleDeclensionSet.Builder.forSupine(verbLemma)
-                .addInflections(supines)
-                .build());
-    }
-
-    private void addSupineSet(LexemeBuilder lexemeBuilder, Optional<ParticipleDeclensionSet> supineSet) {
-        if (supineSet.isEmpty()) {
-            return;
-        }
-
-        VerbDetails.Builder detailsBuilder = getVerbDetailsBuilder(lexemeBuilder);
-        detailsBuilder.addParticipleSet(supineSet.get());
-        lexemeBuilder.setPartOfSpeechDetails(detailsBuilder.build());
-    }
-
-    private VerbDetails.Builder getVerbDetailsBuilder(LexemeBuilder lexemeBuilder) {
-        if (lexemeBuilder.getPartOfSpeechDetails() instanceof VerbDetails details) {
-            return details.toBuilder();
-        }
-        return new VerbDetails.Builder();
-    }
-
-    private Participle buildParticiple(String formValue, List<String> tags) {
-        Participle.Builder builder = new Participle.Builder(normalizeFormValue(formValue));
-        for (String tag : tags) {
-            parserSupport.applyToInflection(builder, tag, logger);
-        }
-        return builder.build();
-    }
-
 
     private void addInflection(LexemeBuilder lexemeBuilder, Optional<Conjugation> optionalConjugation){
         if(optionalConjugation.isPresent()) {
@@ -212,10 +179,6 @@ public class POSVerbParser implements PartOfSpeechParser {
         return false;
     }
 
-    private boolean isSupine(List<String> tags) {
-        return tags.contains(SUPINE_TAG);
-    }
-
     private List<String> collectTags(JsonNode formNode) {
         List<String> tags = new ArrayList<>();
         for (JsonNode tag : formNode.path(TAGS.get())) {
@@ -251,5 +214,44 @@ public class POSVerbParser implements PartOfSpeechParser {
                 tags.add(GrammaticalParticipleTense.PRESENT_ACTIVE.name().toLowerCase());
             }
         }
+    }
+
+
+    // --------------------------------------- SUPINE METHODS ---------------------------------- //
+
+    private boolean isSupine(List<String> tags) {
+        return tags.contains(SUPINE.get());
+    }
+
+    private Participle buildSupineInflection(String formValue, List<String> tags){
+        // supine inflections apply to all genders but Wiktionary doesn't add gender tags to supine forms
+        for(GrammaticalGender gender : GrammaticalGender.values()){
+            tags.add(gender.getTag());
+        }
+
+        return buildParticiple(formValue, tags);
+    }
+
+    private Participle buildParticiple(String formValue, List<String> tags) {
+        Participle.Builder builder = new Participle.Builder(normalizeFormValue(formValue));
+        for (String tag : tags) {
+            parserSupport.applyToInflection(builder, tag, logger);
+        }
+        return builder.build();
+    }
+
+    private void addParticipleDeclensionSet(LexemeBuilder lexemeBuilder, List<Participle> supineInflections) {
+        ParticipleDeclensionSet supineSet = ParticipleDeclensionSet.Builder.forSupine(lexemeBuilder.getLemma())
+                .addInflections(supineInflections)
+                .build();
+
+        lexemeBuilder.setPartOfSpeechDetails(getVerbDetailsBuilder(lexemeBuilder).addParticipleSet(supineSet).build());
+    }
+
+    private VerbDetails.Builder getVerbDetailsBuilder(LexemeBuilder lexemeBuilder) {
+        if (lexemeBuilder.getPartOfSpeechDetails() instanceof VerbDetails details) {
+            return details.toBuilder();
+        }
+        return new VerbDetails.Builder();
     }
 }

--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/StagedParticipleData.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/StagedParticipleData.java
@@ -100,9 +100,8 @@ public class StagedParticipleData implements LinkableData{
 
     /**
      * Projects this participle set into the compound (participle + esse) forms of the
-     * perfect-system tenses, one per gender. The gendered forms supersede the ungendered
-     * baseline added when the parent verb itself was parsed, which reused the singular
-     * participle base for plurals.
+     * perfect-system tenses, one per gender. The gendered forms supersede the single
+     * default form added from the main lemma entry of the lexeme
      */
     private void updateVerbWithGenderedCompoundForms(LexemeBuilder builder, VerbDetails verbDetails) {
         // if this is a perfect participle set and passive, OR it's active, but the verb is deponent,

--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataKeyWord.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataKeyWord.java
@@ -2,6 +2,9 @@ package com.annepolis.lexiconmeum.ingest.wiktionary;
 
 public enum WiktionaryLexicalDataKeyWord {
     PARTICIPLE("participle"),
+    GERUND("gerund"),
+    SUPINE("supine"),
+    SIGMATIC("sigmatic"),
     FORM_OF("form_of");
 
     private final String keyWord;

--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/GrammaticalNumber.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/GrammaticalNumber.java
@@ -3,5 +3,9 @@ package com.annepolis.lexiconmeum.shared.model.grammar;
 // Order is important (affects api response)
 public enum GrammaticalNumber {
     SINGULAR,
-    PLURAL
+    PLURAL;
+
+    public String getTag() {
+        return this.name().toLowerCase();
+    }
 }

--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/GrammaticalParticipleTense.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/GrammaticalParticipleTense.java
@@ -10,7 +10,8 @@ public enum GrammaticalParticipleTense {
     PERFECT_PASSIVE("Perfect Passive Participle", "Perfect Passive Participle"),
     FUTURE_ACTIVE("Future Active Participle", "Future Active Participle"),
     FUTURE_PASSIVE("Gerundive", "Future Passive Participle"),
-    SUPINE("Supine", "Supine");
+    SUPINE("Supine", "Supine"),
+    GERUND("Gerund", "Gerund");
 
     private final String displayName;
     private final String alternativeName;
@@ -50,7 +51,10 @@ public enum GrammaticalParticipleTense {
     public static GrammaticalParticipleTense fromVoiceAndTense(GrammaticalVoice voice, GrammaticalTense tense) {
         if (tense == GrammaticalTense.SUPINE) {
             return SUPINE;
-        } else if (voice == GrammaticalVoice.ACTIVE && tense == GrammaticalTense.PRESENT) {
+        } else if (tense == GrammaticalTense.GERUND) {
+            return GERUND;
+        }
+        else if (voice == GrammaticalVoice.ACTIVE && tense == GrammaticalTense.PRESENT) {
             return PRESENT_ACTIVE;
         } else if (voice == GrammaticalVoice.ACTIVE && tense == GrammaticalTense.FUTURE) {
             return FUTURE_ACTIVE;

--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/GrammaticalParticipleTense.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/GrammaticalParticipleTense.java
@@ -9,7 +9,8 @@ public enum GrammaticalParticipleTense {
     PERFECT_ACTIVE("Perfect Passive Participle", "Perfect Active Participle"),
     PERFECT_PASSIVE("Perfect Passive Participle", "Perfect Passive Participle"),
     FUTURE_ACTIVE("Future Active Participle", "Future Active Participle"),
-    FUTURE_PASSIVE("Gerundive", "Future Passive Participle");
+    FUTURE_PASSIVE("Gerundive", "Future Passive Participle"),
+    SUPINE("Supine", "Supine");
 
     private final String displayName;
     private final String alternativeName;
@@ -47,7 +48,9 @@ public enum GrammaticalParticipleTense {
      * @throws IllegalArgumentException if the combination is not valid for participles
      */
     public static GrammaticalParticipleTense fromVoiceAndTense(GrammaticalVoice voice, GrammaticalTense tense) {
-        if (voice == GrammaticalVoice.ACTIVE && tense == GrammaticalTense.PRESENT) {
+        if (tense == GrammaticalTense.SUPINE) {
+            return SUPINE;
+        } else if (voice == GrammaticalVoice.ACTIVE && tense == GrammaticalTense.PRESENT) {
             return PRESENT_ACTIVE;
         } else if (voice == GrammaticalVoice.ACTIVE && tense == GrammaticalTense.FUTURE) {
             return FUTURE_ACTIVE;

--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/GrammaticalTense.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/GrammaticalTense.java
@@ -8,7 +8,8 @@ public enum GrammaticalTense {
     PERFECT("perfect","Present Perfect"),
     PLUPERFECT("Pluperfect","Past Perfect"),
     FUTURE("Future", "Simple Future"),
-    FUTURE_PERFECT("Future Perfect","Future Perfect");
+    FUTURE_PERFECT("Future Perfect","Future Perfect"),
+    SUPINE("Supine", "Supine");
 
 
 

--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/GrammaticalTense.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/GrammaticalTense.java
@@ -9,7 +9,8 @@ public enum GrammaticalTense {
     PLUPERFECT("Pluperfect","Past Perfect"),
     FUTURE("Future", "Simple Future"),
     FUTURE_PERFECT("Future Perfect","Future Perfect"),
-    SUPINE("Supine", "Supine");
+    SUPINE("Supine", "Supine"),
+    GERUND("Gerund", "Gerund");
 
 
 

--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/partofspeech/ParticipleDeclensionSet.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/partofspeech/ParticipleDeclensionSet.java
@@ -35,6 +35,9 @@ public class ParticipleDeclensionSet {
     }
 
     public String getParticipleSetKey(){
+        if (participleTense == GrammaticalParticipleTense.SUPINE) {
+            return InflectionKey.buildSupineParticipleSetKey();
+        }
         return InflectionKey.buildParticipleSetKey(voice, tense);
     }
 
@@ -72,6 +75,17 @@ public class ParticipleDeclensionSet {
                 @NonNull String tenseLemma
         ){
             this.voice = voice;
+            this.tense = tense;
+            this.tenseLemma = tenseLemma;
+        }
+
+        /** Creates a non-gendered supine set without assigning a grammatical voice. */
+        public static Builder forSupine(@NonNull String tenseLemma) {
+            return new Builder(GrammaticalTense.SUPINE, tenseLemma);
+        }
+
+        private Builder(GrammaticalTense tense, String tenseLemma) {
+            this.voice = null;
             this.tense = tense;
             this.tenseLemma = tenseLemma;
         }

--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/inflection/InflectionKey.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/inflection/InflectionKey.java
@@ -171,6 +171,10 @@ public final class InflectionKey {
         return buildKeyPart(voice, true) + buildKeyPart(tense);
     }
 
+    public static String buildSupineParticipleSetKey() {
+        return GrammaticalParticipleTense.SUPINE.name();
+    }
+
 
     /**
      * Builds a unique key for a participle's inflectional properties.

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ParticipleTableDTO.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ParticipleTableDTO.java
@@ -2,12 +2,14 @@ package com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.inflection
 
 import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalCase;
 import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalNumber;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 import java.util.Map;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(name = "ParticipleTable")
 public class ParticipleTableDTO implements InflectionTableDTO  {
 
@@ -31,10 +33,12 @@ public class ParticipleTableDTO implements InflectionTableDTO  {
         return tenses;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class ParticipleTenseDTO implements TenseDTO {
         private String defaultName;
         private String altName;
         private DeclensionTableDTO declensionDTO;
+        private Map<GrammaticalCase, List<String>> formsByCase;
 
         public String getDefaultName() {
             return defaultName;
@@ -53,11 +57,19 @@ public class ParticipleTableDTO implements InflectionTableDTO  {
         }
 
         public Map<GrammaticalNumber, Map<GrammaticalCase, String>> getDeclensions() {
-            return declensionDTO.getInflectionTable();
+            return declensionDTO == null ? null : declensionDTO.getInflectionTable();
         }
 
         public void setDeclensions(DeclensionTableDTO declensionDTO) {
             this.declensionDTO = declensionDTO;
+        }
+
+        public Map<GrammaticalCase, List<String>> getFormsByCase() {
+            return formsByCase;
+        }
+
+        public void setFormsByCase(Map<GrammaticalCase, List<String>> formsByCase) {
+            this.formsByCase = formsByCase;
         }
     }
 }

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ParticipleTableMapper.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ParticipleTableMapper.java
@@ -4,6 +4,7 @@ import com.annepolis.lexiconmeum.shared.model.Lexeme;
 import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalCase;
 import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalGender;
 import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalNumber;
+import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalTense;
 import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.ParticipleDeclensionSet;
 import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.VerbDetails;
 import com.annepolis.lexiconmeum.shared.model.inflection.Inflection;
@@ -43,6 +44,7 @@ public class ParticipleTableMapper {
             dto.setTenses(entry.getValue());
             participles.add(dto);
         }
+
         return participles;
     }
 
@@ -78,7 +80,9 @@ public class ParticipleTableMapper {
     // Create a new
     private ParticipleTableDTO.ParticipleTenseDTO getTenseDTOWithGender(ParticipleDeclensionSet participleSet, List<Participle> participles) {
         // Create a declension table for this gender/tense combination
-        DeclensionTableDTO declensionTable = createDeclensionTable(participles);
+        DeclensionTableDTO declensionTable = isVerbalNoun(participleSet.getTense()) ?
+                createSupineDeclensionTable(participles) :
+                createDeclensionTable(participles);
 
         // Create tense DTO for the given gen
         ParticipleTableDTO.ParticipleTenseDTO tenseDTO = new ParticipleTableDTO.ParticipleTenseDTO();
@@ -86,6 +90,31 @@ public class ParticipleTableMapper {
         tenseDTO.setAltName(participleSet.getParticipleTense().getAlternativeName());
         tenseDTO.setDeclensions(declensionTable);
         return tenseDTO;
+    }
+
+    private Boolean isVerbalNoun(GrammaticalTense tense){
+        return tense.equals(GrammaticalTense.SUPINE);
+    }
+
+    private DeclensionTableDTO createSupineDeclensionTable(List<Participle> participles) {
+
+        DeclensionTableDTO declensionTable = new DeclensionTableDTO();
+        Map<GrammaticalNumber, Map<GrammaticalCase, String>> table = new EnumMap<>(GrammaticalNumber.class);
+
+        for (Participle participle : participles) {
+
+            GrammaticalCase grammaticalCase = participle.getGrammaticalCase();
+            String form = participle.getForm();
+
+            // Supine forms apply to both
+            table.computeIfAbsent(GrammaticalNumber.SINGULAR, k -> new EnumMap<>(GrammaticalCase.class))
+                    .put(grammaticalCase, form);
+            table.computeIfAbsent(GrammaticalNumber.PLURAL, k -> new EnumMap<>(GrammaticalCase.class))
+                    .put(grammaticalCase, form);
+        }
+
+        declensionTable.setInflectionTable(table);
+        return declensionTable;
     }
 
     private DeclensionTableDTO createDeclensionTable(List<Participle> participles) {
@@ -113,7 +142,6 @@ public class ParticipleTableMapper {
         for (Inflection inflection : inflections) {
             if(inflection instanceof Participle participle ) {
                 Set<GrammaticalGender> genders = participle.getGenders();
-
 
                 // Handle multiple genders - if an inflection has multiple genders,
                 // it applies to all of them

--- a/src/test/java/com/annepolis/lexiconmeum/ingest/wiktionary/VerbParserTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/ingest/wiktionary/VerbParserTest.java
@@ -6,9 +6,13 @@ import com.annepolis.lexiconmeum.ingest.tagmapping.LexicalTagResolver;
 import com.annepolis.lexiconmeum.shared.model.LexemeBuilder;
 import com.annepolis.lexiconmeum.shared.model.grammar.*;
 import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.PartOfSpeech;
+import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.ParticipleDeclensionSet;
+import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.VerbDetails;
 import com.annepolis.lexiconmeum.shared.model.inflection.Conjugation;
 import com.annepolis.lexiconmeum.shared.model.inflection.Inflection;
 import com.annepolis.lexiconmeum.shared.model.inflection.InflectionKey;
+import com.annepolis.lexiconmeum.shared.model.inflection.Participle;
+import com.annepolis.lexiconmeum.shared.model.Lexeme;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -20,6 +24,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static com.annepolis.lexiconmeum.ingest.wiktionary.WiktionaryLexicalDataJsonKey.FORMS;
+import static com.annepolis.lexiconmeum.shared.model.inflection.InflectionKey.buildSupineParticipleSetKey;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class VerbParserTest {
@@ -81,6 +86,49 @@ class VerbParserTest {
 
     static String generateForm ( String participle,  String esseForm ) {
         return participle + " " + esseForm;
+    }
+
+    @org.junit.jupiter.api.Test
+    void addInflectionsRetainsBothSupineCasesAndAlternatives() throws IOException {
+        JsonNode root = JsonTestDataManager.INSTANCE.getRealNode("sequor", PartOfSpeech.VERB, "testDataVerb.jsonl");
+        POSVerbParser parser = new POSVerbParser(new CompoundInflectionGenerator(new EsseFormProvider()), PARSER_SUPPORT);
+        LexemeBuilder lexemeBuilder = new LexemeBuilder("sequor", PartOfSpeech.VERB, "1");
+
+        parser.addInflections(lexemeBuilder, root.path(FORMS.get()));
+        ParticipleDeclensionSet set = ((VerbDetails) lexemeBuilder.getPartOfSpeechDetails())
+                .getParticiples()
+                .get(buildSupineParticipleSetKey());
+
+        assertEquals(GrammaticalParticipleTense.SUPINE, set.getParticipleTense());
+        assertEquals("SUPINE", set.getParticipleSetKey());
+
+        Participle accusative = findByCase(set, GrammaticalCase.ACCUSATIVE);
+        assertEquals("secūtum", accusative.getForm());
+        assertEquals("sequūtum", accusative.getAlternativeForm());
+
+        Participle ablative = findByCase(set, GrammaticalCase.ABLATIVE);
+        assertEquals("secūtū", ablative.getForm());
+        assertEquals("sequūtū", ablative.getAlternativeForm());
+    }
+
+    @org.junit.jupiter.api.Test
+    void parsedVerbAttachesSupineSetWithoutStaging() throws IOException {
+        Lexeme lexeme = JsonTestDataManager.INSTANCE.getParsedVerbLexeme("sequor", "testDataVerb.jsonl");
+
+        VerbDetails details = (VerbDetails) lexeme.getPartOfSpeechDetails();
+        assertEquals(1, details.getParticiples().size());
+        assertEquals(
+                GrammaticalParticipleTense.SUPINE,
+                details.getParticiples().get(buildSupineParticipleSetKey()).getParticipleTense()
+        );
+    }
+
+    private static Participle findByCase(ParticipleDeclensionSet set, GrammaticalCase grammaticalCase) {
+        return set.getInflectionIndex().values().stream()
+                .map(Participle.class::cast)
+                .filter(participle -> participle.getGrammaticalCase() == grammaticalCase)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing " + grammaticalCase + " supine"));
     }
 
     static class ConjugationTestCase {

--- a/src/test/java/com/annepolis/lexiconmeum/ingest/wiktionary/VerbParserTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/ingest/wiktionary/VerbParserTest.java
@@ -3,6 +3,7 @@ package com.annepolis.lexiconmeum.ingest.wiktionary;
 
 import com.annepolis.lexiconmeum.ingest.tagmapping.EsseFormProvider;
 import com.annepolis.lexiconmeum.ingest.tagmapping.LexicalTagResolver;
+import com.annepolis.lexiconmeum.shared.model.Lexeme;
 import com.annepolis.lexiconmeum.shared.model.LexemeBuilder;
 import com.annepolis.lexiconmeum.shared.model.grammar.*;
 import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.PartOfSpeech;
@@ -12,8 +13,8 @@ import com.annepolis.lexiconmeum.shared.model.inflection.Conjugation;
 import com.annepolis.lexiconmeum.shared.model.inflection.Inflection;
 import com.annepolis.lexiconmeum.shared.model.inflection.InflectionKey;
 import com.annepolis.lexiconmeum.shared.model.inflection.Participle;
-import com.annepolis.lexiconmeum.shared.model.Lexeme;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import tools.jackson.databind.JsonNode;
@@ -88,7 +89,7 @@ class VerbParserTest {
         return participle + " " + esseForm;
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void addInflectionsRetainsBothSupineCasesAndAlternatives() throws IOException {
         JsonNode root = JsonTestDataManager.INSTANCE.getRealNode("sequor", PartOfSpeech.VERB, "testDataVerb.jsonl");
         POSVerbParser parser = new POSVerbParser(new CompoundInflectionGenerator(new EsseFormProvider()), PARSER_SUPPORT);
@@ -111,7 +112,7 @@ class VerbParserTest {
         assertEquals("sequūtū", ablative.getAlternativeForm());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void parsedVerbAttachesSupineSetWithoutStaging() throws IOException {
         Lexeme lexeme = JsonTestDataManager.INSTANCE.getParsedVerbLexeme("sequor", "testDataVerb.jsonl");
 

--- a/src/test/java/com/annepolis/lexiconmeum/shared/model/grammar/GrammaticalParticipleTenseTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/shared/model/grammar/GrammaticalParticipleTenseTest.java
@@ -48,6 +48,11 @@ class GrammaticalParticipleTenseTest {
                 GrammaticalParticipleTense.PERFECT_ACTIVE,
                 GrammaticalParticipleTense.fromVoiceAndTense(GrammaticalVoice.ACTIVE, GrammaticalTense.PERFECT)
         );
+
+        assertEquals(
+                GrammaticalParticipleTense.SUPINE,
+                GrammaticalParticipleTense.fromVoiceAndTense(null, GrammaticalTense.SUPINE)
+        );
     }
 
     @Test

--- a/src/test/java/com/annepolis/lexiconmeum/shared/model/grammar/partofspeech/ParticipleDeclensionSetTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/shared/model/grammar/partofspeech/ParticipleDeclensionSetTest.java
@@ -57,4 +57,20 @@ class ParticipleDeclensionSetTest {
         assertEquals(altForm, participle.getAlternativeForm());
 
     }
+
+    @Test
+    void forSupineBuildsNonGenderedSetWithDedicatedKey() {
+        Participle supine = new Participle.Builder("amātum")
+                .setGrammaticalCase(GrammaticalCase.ACCUSATIVE)
+                .build();
+
+        ParticipleDeclensionSet set = ParticipleDeclensionSet.Builder.forSupine("amātum")
+                .addInflection(supine)
+                .build();
+
+        assertEquals(GrammaticalParticipleTense.SUPINE, set.getParticipleTense());
+        assertEquals(GrammaticalTense.SUPINE, set.getTense());
+        assertEquals(InflectionKey.buildSupineParticipleSetKey(), set.getParticipleSetKey());
+        assertEquals(supine, set.getInflectionIndex().get(InflectionKey.of(supine)));
+    }
 }

--- a/src/test/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/LexemeDetailControllerIntegrationTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/LexemeDetailControllerIntegrationTest.java
@@ -175,6 +175,29 @@ class LexemeDetailControllerIntegrationTest {
     }
 
     @Test
+    void supineFormsAppearInDetailResponse() {
+        UUID lexemeId = new LexemeBuilder("sequor", PartOfSpeech.VERB, "1").build().getId();
+
+        String url = UriComponentsBuilder
+                .fromUriString(getFullBaseUrl())
+                .path(ApiRoutes.LEXEME_DETAIL)
+                .queryParam("type", "VERB")
+                .buildAndExpand(lexemeId)
+                .toUriString();
+
+        ResponseEntity<String> response = restClient.get().uri(url).retrieve().toEntity(String.class);
+        String body = response.getBody();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(body);
+        assertTrue(body.contains("\"defaultName\":\"Supine\""));
+        assertTrue(body.contains("\"declensions\""));
+        assertTrue(body.contains("\"ACCUSATIVE\":\"secūtum\""));
+        assertTrue(body.contains("\"ABLATIVE\":\"secūtū\""));
+        assertFalse(body.contains("\"gender\":null"));
+    }
+
+    @Test
     void testTypeMismatchReturnsConflict() {
         LexemeBuilder lexemeBuilder = new LexemeBuilder("poculum", PartOfSpeech.NOUN, "1");
         UUID lexemeId = lexemeBuilder.build().getId();

--- a/src/test/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ParticipleTableMapperTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ParticipleTableMapperTest.java
@@ -15,6 +15,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -125,13 +126,16 @@ class ParticipleTableMapperTest {
 
         // Get the expected tenses (excluding PARTICIPLE which is a base enum value)
         List<GrammaticalParticipleTense> expectedTenses = Arrays.stream(GrammaticalParticipleTense.values())
-                .filter(p -> p != GrammaticalParticipleTense.PARTICIPLE)
+                .filter(p -> p != GrammaticalParticipleTense.PARTICIPLE
+                        && p != GrammaticalParticipleTense.SUPINE
+                        && p != GrammaticalParticipleTense.PERFECT_ACTIVE
+                        && p != GrammaticalParticipleTense.GERUND)
                 .toList();
 
         for (ParticipleTableDTO dto : dtos) {
             List<ParticipleTableDTO.ParticipleTenseDTO> tenses = dto.getTenses();
 
-            assertEquals(expectedTenses.size()-1, tenses.size(),
+            assertEquals(expectedTenses.size(), tenses.size(),
                     "Gender " + dto.getGender() + " should have all tenses");
 
             // Verify each expected tense is present
@@ -144,6 +148,48 @@ class ParticipleTableMapperTest {
                             " is missing tense: " + expectedTense.getDisplayName());
                 }
             }
+        }
+    }
+
+    @Test
+    void supineIsMappedInEachGenderedParticipleTable() {
+        Participle.Builder accusativeBuilder = new Participle.Builder("amātum")
+                .setGrammaticalCase(GrammaticalCase.ACCUSATIVE);
+        Participle.Builder ablativeBuilder = new Participle.Builder("amātū")
+                .setGrammaticalCase(GrammaticalCase.ABLATIVE);
+        for (GrammaticalGender gender : GrammaticalGender.values()) {
+            accusativeBuilder.addGender(gender);
+            ablativeBuilder.addGender(gender);
+        }
+
+        VerbDetails details = ((VerbDetails) getTestLexeme().getPartOfSpeechDetails()).toBuilder()
+                .addParticipleSet(ParticipleDeclensionSet.Builder.forSupine("amātum")
+                        .addInflection(accusativeBuilder.build())
+                        .addInflection(ablativeBuilder.build())
+                        .build())
+                .build();
+        Lexeme lexeme = LexemeBuilder.fromLexeme(getTestLexeme())
+                .setPartOfSpeechDetails(details)
+                .build();
+
+        List<ParticipleTableDTO> tables = new ParticipleTableMapper().toInflectionTableDTO(lexeme);
+        for (ParticipleTableDTO table : tables) {
+            ParticipleTableDTO.ParticipleTenseDTO supine = table.getTenses().get(table.getTenses().size() - 1);
+
+            assertEquals("Supine", supine.getDefaultName());
+            assertEquals(
+                    Map.of(
+                            GrammaticalNumber.SINGULAR, Map.of(
+                                    GrammaticalCase.ACCUSATIVE, "amātum",
+                                    GrammaticalCase.ABLATIVE, "amātū"
+                            ),
+                            GrammaticalNumber.PLURAL, Map.of(
+                                    GrammaticalCase.ACCUSATIVE, "amātum",
+                                    GrammaticalCase.ABLATIVE, "amātū"
+                            )
+                    ),
+                    supine.getDeclensions()
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- ingest supine forms into verb participle data
- expose supines in gendered participle tables
- add parser, mapper, and detail endpoint coverage
- document feature-branch and release-branch workflow

## Tests
- ./mvnw -Dtest=VerbParserTest,ParticipleTableMapperTest test
- ./mvnw -Dtest=LexemeDetailControllerIntegrationTest test