### PR TITLE
Add gerund ingest and detail API support

### DIFF
--- a/docs/planning/add-gerund.md
+++ b/docs/planning/add-gerund.md
@@ -1,0 +1,14 @@
+# Add Gerund to Ingest and expose in Details API
+
+Re-use the existing methods handling the supine forms when possible. Rename method names specific to `supine` to `verbalNoun` when adapting them to handle both supine and gerund forms.
+
+## Planned changes
+
+- `src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/POSVerbParser.java`: recognize gerund-tagged verb forms, parse them through the shared verbal-noun path, and attach distinct supine and gerund declension sets to the verb.
+- `src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/partofspeech/ParticipleDeclensionSet.java`: generalize the supine-only builder and set-key selection so both non-gendered verbal-noun types are represented without a voice.
+- `src/main/java/com/annepolis/lexiconmeum/shared/model/inflection/InflectionKey.java`: replace the supine-specific set-key helper with a verbal-noun key helper that keeps supine and gerund sets distinct.
+- `src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ParticipleTableMapper.java`: map both supine and gerund sets through the verbal-noun declension-table layout so gerund forms appear in each gender table with their case forms.
+- `src/test/java/com/annepolis/lexiconmeum/ingest/wiktionary/VerbParserTest.java`: cover gerund ingestion, cases, and coexistence with supine forms using the existing verb fixture.
+- `src/test/java/com/annepolis/lexiconmeum/shared/model/grammar/partofspeech/ParticipleDeclensionSetTest.java`: cover construction and unique keys for both verbal-noun sets.
+- `src/test/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ParticipleTableMapperTest.java`: verify gerund labeling and declension output alongside supine output.
+- `src/test/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/LexemeDetailControllerIntegrationTest.java`: verify gerund forms are present in the serialized verb-details response.

--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/POSVerbParser.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/POSVerbParser.java
@@ -19,11 +19,14 @@ import org.springframework.stereotype.Component;
 import tools.jackson.databind.JsonNode;
 
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 import static com.annepolis.lexiconmeum.ingest.wiktionary.WiktionaryLexicalDataJsonKey.*;
+import static com.annepolis.lexiconmeum.ingest.wiktionary.WiktionaryLexicalDataKeyWord.GERUND;
 import static com.annepolis.lexiconmeum.ingest.wiktionary.WiktionaryLexicalDataKeyWord.SIGMATIC;
 import static com.annepolis.lexiconmeum.ingest.wiktionary.WiktionaryLexicalDataKeyWord.SUPINE;
 
@@ -82,7 +85,8 @@ public class POSVerbParser implements PartOfSpeechParser {
     }
 
     public void addInflections(LexemeBuilder lexemeBuilder, JsonNode formsNode) {
-        List<Participle> supineInflections = new ArrayList<>();
+        Map<GrammaticalTense, List<Participle>> verbalNounInflections = new EnumMap<>(GrammaticalTense.class);
+        verbalNounInflections.put(GrammaticalTense.SUPINE, new ArrayList<>());
 
         for (JsonNode formNode : formsNode) {
             try {
@@ -91,8 +95,10 @@ public class POSVerbParser implements PartOfSpeechParser {
                     String formValue = formNode.path(FORM.get()).asString();
                     List<String> tags = collectTags(formNode);
 
-                    if (isSupine(tags)) {
-                        supineInflections.add(buildSupineInflection(formValue, tags));
+                    if (isVerbalNoun(tags)) {
+                        GrammaticalTense verbalNounTense = getVerbalNounTense(tags);
+                        verbalNounInflections.computeIfAbsent(verbalNounTense, tense -> new ArrayList<>())
+                                .add(buildVerbalNounInflection(formValue, tags));
                         continue;
                     }
 
@@ -108,7 +114,7 @@ public class POSVerbParser implements PartOfSpeechParser {
             }
         }
 
-        addParticipleDeclensionSet(lexemeBuilder, supineInflections);
+        addVerbalNounDeclensionSets(lexemeBuilder, verbalNounInflections);
     }
 
     private void addInflection(LexemeBuilder lexemeBuilder, Optional<Conjugation> optionalConjugation){
@@ -217,14 +223,18 @@ public class POSVerbParser implements PartOfSpeechParser {
     }
 
 
-    // --------------------------------------- SUPINE METHODS ---------------------------------- //
+    // --------------------------------------- VERBAL NOUN METHODS ---------------------------------- //
 
-    private boolean isSupine(List<String> tags) {
-        return tags.contains(SUPINE.get());
+    private boolean isVerbalNoun(List<String> tags) {
+        return tags.contains(SUPINE.get()) || tags.contains(GERUND.get());
     }
 
-    private Participle buildSupineInflection(String formValue, List<String> tags){
-        // supine inflections apply to all genders but Wiktionary doesn't add gender tags to supine forms
+    private GrammaticalTense getVerbalNounTense(List<String> tags) {
+        return tags.contains(SUPINE.get()) ? GrammaticalTense.SUPINE : GrammaticalTense.GERUND;
+    }
+
+    private Participle buildVerbalNounInflection(String formValue, List<String> tags){
+        // Verbal nouns apply to all genders but Wiktionary doesn't add gender tags to their forms.
         for(GrammaticalGender gender : GrammaticalGender.values()){
             tags.add(gender.getTag());
         }
@@ -240,12 +250,20 @@ public class POSVerbParser implements PartOfSpeechParser {
         return builder.build();
     }
 
-    private void addParticipleDeclensionSet(LexemeBuilder lexemeBuilder, List<Participle> supineInflections) {
-        ParticipleDeclensionSet supineSet = ParticipleDeclensionSet.Builder.forSupine(lexemeBuilder.getLemma())
-                .addInflections(supineInflections)
-                .build();
+    private void addVerbalNounDeclensionSets(
+            LexemeBuilder lexemeBuilder,
+            Map<GrammaticalTense, List<Participle>> verbalNounInflections
+    ) {
+        VerbDetails.Builder verbDetailsBuilder = getVerbDetailsBuilder(lexemeBuilder);
+        for (Map.Entry<GrammaticalTense, List<Participle>> entry : verbalNounInflections.entrySet()) {
+            ParticipleDeclensionSet verbalNounSet = ParticipleDeclensionSet.Builder
+                    .forVerbalNoun(entry.getKey(), lexemeBuilder.getLemma())
+                    .addInflections(entry.getValue())
+                    .build();
+            verbDetailsBuilder.addParticipleSet(verbalNounSet);
+        }
 
-        lexemeBuilder.setPartOfSpeechDetails(getVerbDetailsBuilder(lexemeBuilder).addParticipleSet(supineSet).build());
+        lexemeBuilder.setPartOfSpeechDetails(verbDetailsBuilder.build());
     }
 
     private VerbDetails.Builder getVerbDetailsBuilder(LexemeBuilder lexemeBuilder) {

--- a/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/StagedParticipleData.java
+++ b/src/main/java/com/annepolis/lexiconmeum/ingest/wiktionary/StagedParticipleData.java
@@ -114,7 +114,7 @@ public class StagedParticipleData implements LinkableData{
                     compoundInflectionGenerator.generateAllGenderedCompoundForms(participleDeclensionSet);
 
             for (Conjugation genderedForm : genderedForms) {
-                builder.removeInflection(InflectionKey.joinConjugationParts(
+                builder.removeInflection(InflectionKey.buildConjugationKey(
                         genderedForm.getVoice(),
                         genderedForm.getMood(),
                         genderedForm.getTense(),

--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/partofspeech/ParticipleDeclensionSet.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/grammar/partofspeech/ParticipleDeclensionSet.java
@@ -35,8 +35,8 @@ public class ParticipleDeclensionSet {
     }
 
     public String getParticipleSetKey(){
-        if (participleTense == GrammaticalParticipleTense.SUPINE) {
-            return InflectionKey.buildSupineParticipleSetKey();
+        if (voice == null) {
+            return InflectionKey.buildVerbalNounParticipleSetKey(tense);
         }
         return InflectionKey.buildParticipleSetKey(voice, tense);
     }
@@ -79,9 +79,9 @@ public class ParticipleDeclensionSet {
             this.tenseLemma = tenseLemma;
         }
 
-        /** Creates a non-gendered supine set without assigning a grammatical voice. */
-        public static Builder forSupine(@NonNull String tenseLemma) {
-            return new Builder(GrammaticalTense.SUPINE, tenseLemma);
+        /** Creates a verbal-noun set without assigning a grammatical voice. */
+        public static Builder forVerbalNoun(@NonNull GrammaticalTense tense, @NonNull String tenseLemma) {
+            return new Builder(tense, tenseLemma);
         }
 
         private Builder(GrammaticalTense tense, String tenseLemma) {

--- a/src/main/java/com/annepolis/lexiconmeum/shared/model/inflection/InflectionKey.java
+++ b/src/main/java/com/annepolis/lexiconmeum/shared/model/inflection/InflectionKey.java
@@ -25,7 +25,7 @@ public final class InflectionKey {
         }
     }
     public static String buildConjugationKey(Conjugation conjugation) {
-        return joinConjugationParts(
+        return buildKey(
                 conjugation.getVoice(),
                 conjugation.getMood(),
                 conjugation.getTense(),
@@ -35,43 +35,18 @@ public final class InflectionKey {
                 );
     }
 
-    public static String joinConjugationParts(
+    public static String buildConjugationKey(
             GrammaticalVoice voice,
             GrammaticalMood mood,
             GrammaticalTense tense,
             GrammaticalPerson person,
             GrammaticalNumber number
     ){
-        return joinConjugationParts(voice, mood, tense, person, number, null);
-    }
-
-    public static String joinConjugationParts(
-            GrammaticalVoice voice,
-            GrammaticalMood mood,
-            GrammaticalTense tense,
-            GrammaticalPerson person,
-            GrammaticalNumber number,
-            GrammaticalGender gender
-    ){
-        return buildKeyPart(voice, true)
-        + buildKeyPart(mood)
-        + buildKeyPart(tense)
-        + buildKeyPart(person)
-        + buildKeyPart(number)
-        + buildKeyPart(gender);
-    }
-
-    private static String buildKeyPart(Enum<?>  part){
-        return buildKeyPart(part, false);
-    }
-
-    private static String buildKeyPart(Enum<?>  part, boolean firstOne){
-        String delimiter = firstOne ? "" : KEY_DELIMITER;
-       return part != null ? delimiter + part.name() : "";
+        return buildKey(voice, mood, tense, person, number);
     }
 
     public String buildFirstPrincipalPartKey() {
-        return buildConjugationPrincipalPartKey(
+        return buildKey(
                 GrammaticalVoice.ACTIVE,
                 GrammaticalMood.INDICATIVE,
                 GrammaticalTense.PRESENT,
@@ -81,17 +56,15 @@ public final class InflectionKey {
     }
 
     public String buildSecondPrincipalPartKey() {
-        return buildConjugationPrincipalPartKey(
+        return buildKey(
                 GrammaticalVoice.ACTIVE,
                 GrammaticalMood.INFINITIVE,
-                GrammaticalTense.PRESENT,
-                null,
-                null
+                GrammaticalTense.PRESENT
         );
     }
 
     public String buildThirdPrincipalPartKey() {
-        return buildConjugationPrincipalPartKey(
+        return buildKey(
                 GrammaticalVoice.ACTIVE,
                 GrammaticalMood.INDICATIVE,
                 GrammaticalTense.PERFECT,
@@ -101,7 +74,7 @@ public final class InflectionKey {
     }
 
     public String buildFourthPrincipalPartKey() {
-        return buildConjugationPrincipalPartKey(
+        return buildKey(
                 GrammaticalVoice.PASSIVE,
                 GrammaticalMood.INDICATIVE,
                 GrammaticalTense.PERFECT,
@@ -110,35 +83,23 @@ public final class InflectionKey {
         );
     }
 
-    private static String buildConjugationPrincipalPartKey(
-            GrammaticalVoice voice,
-            GrammaticalMood mood,
-            GrammaticalTense tense,
-            GrammaticalPerson person,
-            GrammaticalNumber number
-    ) {
-        return joinConjugationParts( voice, mood, tense, person, number );
-    }
 
     public static String buildDeclensionKey(Declension declension) {
-        return joinDeclensionParts(declension.getGrammaticalCase(), declension.getNumber());
+        return buildKey(declension.getGrammaticalCase(), declension.getNumber());
     }
 
     public String buildFirstDeclensionPrincipalPartKey(){
-        return joinDeclensionParts(GrammaticalCase.NOMINATIVE, GrammaticalNumber.SINGULAR);
+        return buildKey(GrammaticalCase.NOMINATIVE, GrammaticalNumber.SINGULAR);
     }
 
     public String buildSecondDeclensionPrincipalPartKey(){
-        return joinDeclensionParts(GrammaticalCase.GENITIVE, GrammaticalNumber.SINGULAR);
+        return buildKey(GrammaticalCase.GENITIVE, GrammaticalNumber.SINGULAR);
     }
-    public static String joinDeclensionParts(
-            GrammaticalCase grammaticalCase, GrammaticalNumber number ) {
 
-        return buildKeyPart(grammaticalCase, true)
-                + buildKeyPart(number);
-    }
 
     public static String buildAgreementKey(Agreement agreement) {
+
+
         return joinAgreementParts(
                 agreement.getGrammaticalCase(),
                 agreement.getNumber(),
@@ -148,14 +109,15 @@ public final class InflectionKey {
 
     public static String joinAgreementParts(
             GrammaticalCase grammaticalCase, GrammaticalNumber number, Set<GrammaticalGender> genders, GrammaticalDegree degree ) {
-        String genderPart = genders.stream()
+        java.util.List<Enum<?>> parts = new java.util.ArrayList<>();
+        parts.add(grammaticalCase);
+        parts.add(number);
+        genders.stream()
                 .sorted()
-                .map(g -> buildKeyPart(g))
-                .collect(Collectors.joining());
-        return buildKeyPart(grammaticalCase, true)
-                + buildKeyPart(number)
-                + genderPart
-                + buildKeyPart(degree);
+                .forEach(parts::add);
+        parts.add(degree);
+
+        return buildKey(parts.toArray(Enum<?>[]::new));
     }
 
     /**
@@ -168,11 +130,18 @@ public final class InflectionKey {
      * @return the constructed key as a concatenated string of the voice and tense
      */
     public static String buildParticipleSetKey(GrammaticalVoice voice, GrammaticalTense tense) {
-        return buildKeyPart(voice, true) + buildKeyPart(tense);
+        return buildKey(voice, tense);
     }
 
-    public static String buildSupineParticipleSetKey() {
-        return GrammaticalParticipleTense.SUPINE.name();
+    public static String buildVerbalNounParticipleSetKey(GrammaticalTense tense) {
+        return buildKey(tense);
+    }
+
+    private static String buildKey(Enum<?>... parts) {
+        return java.util.Arrays.stream(parts)
+                .filter(java.util.Objects::nonNull)
+                .map(Enum::name)
+                .collect(Collectors.joining(KEY_DELIMITER));
     }
 
 

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ParticipleTableDTO.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ParticipleTableDTO.java
@@ -2,14 +2,12 @@ package com.annepolis.lexiconmeum.webapi.bff.lexemedetail.dtoassembly.inflection
 
 import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalCase;
 import com.annepolis.lexiconmeum.shared.model.grammar.GrammaticalNumber;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 import java.util.Map;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(name = "ParticipleTable")
 public class ParticipleTableDTO implements InflectionTableDTO  {
 
@@ -33,12 +31,10 @@ public class ParticipleTableDTO implements InflectionTableDTO  {
         return tenses;
     }
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class ParticipleTenseDTO implements TenseDTO {
         private String defaultName;
         private String altName;
         private DeclensionTableDTO declensionDTO;
-        private Map<GrammaticalCase, List<String>> formsByCase;
 
         public String getDefaultName() {
             return defaultName;
@@ -57,19 +53,11 @@ public class ParticipleTableDTO implements InflectionTableDTO  {
         }
 
         public Map<GrammaticalNumber, Map<GrammaticalCase, String>> getDeclensions() {
-            return declensionDTO == null ? null : declensionDTO.getInflectionTable();
+            return declensionDTO.getInflectionTable();
         }
 
         public void setDeclensions(DeclensionTableDTO declensionDTO) {
             this.declensionDTO = declensionDTO;
-        }
-
-        public Map<GrammaticalCase, List<String>> getFormsByCase() {
-            return formsByCase;
-        }
-
-        public void setFormsByCase(Map<GrammaticalCase, List<String>> formsByCase) {
-            this.formsByCase = formsByCase;
         }
     }
 }

--- a/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ParticipleTableMapper.java
+++ b/src/main/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ParticipleTableMapper.java
@@ -81,7 +81,7 @@ public class ParticipleTableMapper {
     private ParticipleTableDTO.ParticipleTenseDTO getTenseDTOWithGender(ParticipleDeclensionSet participleSet, List<Participle> participles) {
         // Create a declension table for this gender/tense combination
         DeclensionTableDTO declensionTable = isVerbalNoun(participleSet.getTense()) ?
-                createSupineDeclensionTable(participles) :
+                createVerbalNounDeclensionTable(participles) :
                 createDeclensionTable(participles);
 
         // Create tense DTO for the given gen
@@ -92,11 +92,11 @@ public class ParticipleTableMapper {
         return tenseDTO;
     }
 
-    private Boolean isVerbalNoun(GrammaticalTense tense){
-        return tense.equals(GrammaticalTense.SUPINE);
+    private boolean isVerbalNoun(GrammaticalTense tense){
+        return tense == GrammaticalTense.SUPINE || tense == GrammaticalTense.GERUND;
     }
 
-    private DeclensionTableDTO createSupineDeclensionTable(List<Participle> participles) {
+    private DeclensionTableDTO createVerbalNounDeclensionTable(List<Participle> participles) {
 
         DeclensionTableDTO declensionTable = new DeclensionTableDTO();
         Map<GrammaticalNumber, Map<GrammaticalCase, String>> table = new EnumMap<>(GrammaticalNumber.class);
@@ -106,7 +106,7 @@ public class ParticipleTableMapper {
             GrammaticalCase grammaticalCase = participle.getGrammaticalCase();
             String form = participle.getForm();
 
-            // Supine forms apply to both
+            // Verbal-noun forms apply to both number rows in the shared table shape.
             table.computeIfAbsent(GrammaticalNumber.SINGULAR, k -> new EnumMap<>(GrammaticalCase.class))
                     .put(grammaticalCase, form);
             table.computeIfAbsent(GrammaticalNumber.PLURAL, k -> new EnumMap<>(GrammaticalCase.class))

--- a/src/test/java/com/annepolis/lexiconmeum/ingest/wiktionary/VerbParserTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/ingest/wiktionary/VerbParserTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static com.annepolis.lexiconmeum.ingest.wiktionary.WiktionaryLexicalDataJsonKey.FORMS;
-import static com.annepolis.lexiconmeum.shared.model.inflection.InflectionKey.buildSupineParticipleSetKey;
+import static com.annepolis.lexiconmeum.shared.model.inflection.InflectionKey.buildVerbalNounParticipleSetKey;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class VerbParserTest {
@@ -67,7 +67,7 @@ class VerbParserTest {
                         String esseForm = ESSE_FORM_PROVIDER.getForm(mood, tense, number, person);
                         if(esseForm != null) {
                             String expectedForm = generateForm("secūtus", esseForm);
-                            String key = InflectionKey.joinConjugationParts(
+                            String key = InflectionKey.buildConjugationKey(
                                     GrammaticalVoice.ACTIVE,
                                     mood,
                                     tense,
@@ -98,7 +98,7 @@ class VerbParserTest {
         parser.addInflections(lexemeBuilder, root.path(FORMS.get()));
         ParticipleDeclensionSet set = ((VerbDetails) lexemeBuilder.getPartOfSpeechDetails())
                 .getParticiples()
-                .get(buildSupineParticipleSetKey());
+                .get(buildVerbalNounParticipleSetKey(GrammaticalTense.SUPINE));
 
         assertEquals(GrammaticalParticipleTense.SUPINE, set.getParticipleTense());
         assertEquals("SUPINE", set.getParticipleSetKey());
@@ -113,14 +113,40 @@ class VerbParserTest {
     }
 
     @Test
-    void parsedVerbAttachesSupineSetWithoutStaging() throws IOException {
+    void addInflectionsRetainsAllGerundCases() throws IOException {
+        JsonNode root = JsonTestDataManager.INSTANCE.getRealNode("sequor", PartOfSpeech.VERB, "testDataVerb.jsonl");
+        POSVerbParser parser = new POSVerbParser(new CompoundInflectionGenerator(new EsseFormProvider()), PARSER_SUPPORT);
+        LexemeBuilder lexemeBuilder = new LexemeBuilder("sequor", PartOfSpeech.VERB, "1");
+
+        parser.addInflections(lexemeBuilder, root.path(FORMS.get()));
+        ParticipleDeclensionSet set = ((VerbDetails) lexemeBuilder.getPartOfSpeechDetails())
+                .getParticiples()
+                .get(buildVerbalNounParticipleSetKey(GrammaticalTense.GERUND));
+
+        assertEquals(GrammaticalParticipleTense.GERUND, set.getParticipleTense());
+        assertEquals("sequendī", findByCase(set, GrammaticalCase.GENITIVE).getForm());
+        assertEquals("sequendō", findByCase(set, GrammaticalCase.DATIVE).getForm());
+        assertEquals("sequendum", findByCase(set, GrammaticalCase.ACCUSATIVE).getForm());
+        assertEquals("sequendō", findByCase(set, GrammaticalCase.ABLATIVE).getForm());
+    }
+
+    @Test
+    void parsedVerbAttachesVerbalNounSetsWithoutStaging() throws IOException {
         Lexeme lexeme = JsonTestDataManager.INSTANCE.getParsedVerbLexeme("sequor", "testDataVerb.jsonl");
 
         VerbDetails details = (VerbDetails) lexeme.getPartOfSpeechDetails();
-        assertEquals(1, details.getParticiples().size());
+        assertEquals(2, details.getParticiples().size());
         assertEquals(
                 GrammaticalParticipleTense.SUPINE,
-                details.getParticiples().get(buildSupineParticipleSetKey()).getParticipleTense()
+                details.getParticiples()
+                        .get(buildVerbalNounParticipleSetKey(GrammaticalTense.SUPINE))
+                        .getParticipleTense()
+        );
+        assertEquals(
+                GrammaticalParticipleTense.GERUND,
+                details.getParticiples()
+                        .get(buildVerbalNounParticipleSetKey(GrammaticalTense.GERUND))
+                        .getParticipleTense()
         );
     }
 
@@ -129,7 +155,7 @@ class VerbParserTest {
                 .map(Participle.class::cast)
                 .filter(participle -> participle.getGrammaticalCase() == grammaticalCase)
                 .findFirst()
-                .orElseThrow(() -> new AssertionError("Missing " + grammaticalCase + " supine"));
+                .orElseThrow(() -> new AssertionError("Missing verbal noun case: " + grammaticalCase));
     }
 
     static class ConjugationTestCase {

--- a/src/test/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataParserTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/ingest/wiktionary/WiktionaryLexicalDataParserTest.java
@@ -7,12 +7,12 @@ import com.annepolis.lexiconmeum.shared.model.LexemeFixtureFactory;
 import com.annepolis.lexiconmeum.shared.model.grammar.*;
 import com.annepolis.lexiconmeum.shared.model.grammar.partofspeech.PartOfSpeech;
 import com.annepolis.lexiconmeum.shared.model.inflection.*;
+import com.annepolis.lexiconmeum.testsupport.TestSupport;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import com.annepolis.lexiconmeum.testsupport.TestSupport;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import tools.jackson.databind.JsonNode;
@@ -330,7 +330,7 @@ class WiktionaryLexicalDataParserTest {
                 .orElseThrow(() -> new AssertionError("'sum' not found in staging"));
 
         assertEquals(PartOfSpeech.VERB, sumStaged.getPartOfSpeech());
-        String key = InflectionKey.joinConjugationParts(GrammaticalVoice.ACTIVE, GrammaticalMood.SUBJUNCTIVE, GrammaticalTense.PERFECT, GrammaticalPerson.FIRST, GrammaticalNumber.SINGULAR);
+        String key = InflectionKey.buildConjugationKey(GrammaticalVoice.ACTIVE, GrammaticalMood.SUBJUNCTIVE, GrammaticalTense.PERFECT, GrammaticalPerson.FIRST, GrammaticalNumber.SINGULAR);
         assertEquals("fuerim", sumStaged.getInflectionIndex().get(key).getForm());
 
     }

--- a/src/test/java/com/annepolis/lexiconmeum/shared/model/grammar/GrammaticalParticipleTenseTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/shared/model/grammar/GrammaticalParticipleTenseTest.java
@@ -53,6 +53,11 @@ class GrammaticalParticipleTenseTest {
                 GrammaticalParticipleTense.SUPINE,
                 GrammaticalParticipleTense.fromVoiceAndTense(null, GrammaticalTense.SUPINE)
         );
+
+        assertEquals(
+                GrammaticalParticipleTense.GERUND,
+                GrammaticalParticipleTense.fromVoiceAndTense(null, GrammaticalTense.GERUND)
+        );
     }
 
     @Test

--- a/src/test/java/com/annepolis/lexiconmeum/shared/model/grammar/partofspeech/ParticipleDeclensionSetTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/shared/model/grammar/partofspeech/ParticipleDeclensionSetTest.java
@@ -59,18 +59,36 @@ class ParticipleDeclensionSetTest {
     }
 
     @Test
-    void forSupineBuildsNonGenderedSetWithDedicatedKey() {
+    void forVerbalNounBuildsSupineWithDedicatedKey() {
         Participle supine = new Participle.Builder("amātum")
                 .setGrammaticalCase(GrammaticalCase.ACCUSATIVE)
                 .build();
 
-        ParticipleDeclensionSet set = ParticipleDeclensionSet.Builder.forSupine("amātum")
+        ParticipleDeclensionSet set = ParticipleDeclensionSet.Builder
+                .forVerbalNoun(GrammaticalTense.SUPINE, "amātum")
                 .addInflection(supine)
                 .build();
 
         assertEquals(GrammaticalParticipleTense.SUPINE, set.getParticipleTense());
         assertEquals(GrammaticalTense.SUPINE, set.getTense());
-        assertEquals(InflectionKey.buildSupineParticipleSetKey(), set.getParticipleSetKey());
+        assertEquals(InflectionKey.buildVerbalNounParticipleSetKey(GrammaticalTense.SUPINE), set.getParticipleSetKey());
         assertEquals(supine, set.getInflectionIndex().get(InflectionKey.of(supine)));
+    }
+
+    @Test
+    void forVerbalNounBuildsGerundWithDedicatedKey() {
+        Participle gerund = new Participle.Builder("amandī")
+                .setGrammaticalCase(GrammaticalCase.GENITIVE)
+                .build();
+
+        ParticipleDeclensionSet set = ParticipleDeclensionSet.Builder
+                .forVerbalNoun(GrammaticalTense.GERUND, "amandum")
+                .addInflection(gerund)
+                .build();
+
+        assertEquals(GrammaticalParticipleTense.GERUND, set.getParticipleTense());
+        assertEquals(GrammaticalTense.GERUND, set.getTense());
+        assertEquals(InflectionKey.buildVerbalNounParticipleSetKey(GrammaticalTense.GERUND), set.getParticipleSetKey());
+        assertEquals(gerund, set.getInflectionIndex().get(InflectionKey.of(gerund)));
     }
 }

--- a/src/test/java/com/annepolis/lexiconmeum/shared/model/inflection/InflectionKeyTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/shared/model/inflection/InflectionKeyTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static com.annepolis.lexiconmeum.shared.model.inflection.InflectionKey.buildParticipleSetKey;
+import static com.annepolis.lexiconmeum.shared.model.inflection.InflectionKey.buildVerbalNounParticipleSetKey;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class InflectionKeyTest {
@@ -63,6 +65,17 @@ class InflectionKeyTest {
     }
 
     @Test
+    void buildsValidVerbalNounKey(){
+        assertEquals(GrammaticalTense.SUPINE.name(), buildVerbalNounParticipleSetKey(GrammaticalTense.SUPINE));
+    }
+
+    @Test
+    void buildsValidParticipleKey(){
+        assertEquals("ACTIVE|FUTURE", buildParticipleSetKey(GrammaticalVoice.ACTIVE, GrammaticalTense.FUTURE));
+
+    }
+
+    @Test
     void buildsValidFirstPrincipalPartKey(){
         InflectionKey builder = new InflectionKey();
         String key = builder.buildFirstPrincipalPartKey();
@@ -81,5 +94,18 @@ class InflectionKeyTest {
         InflectionKey builder = new InflectionKey();
         String key = builder.buildThirdPrincipalPartKey();
         assertEquals("ACTIVE|INDICATIVE|PERFECT|FIRST|SINGULAR", key);
+    }
+
+    @Test
+    void buildsAgreementKey(){
+        Agreement.Builder  builder = new Agreement.Builder("test")
+                .addGender(GrammaticalGender.MASCULINE)
+                .addGender(GrammaticalGender.FEMININE)
+                .setDegree(GrammaticalDegree.POSITIVE)
+                .setNumber(GrammaticalNumber.SINGULAR)
+                .setGrammaticalCase(GrammaticalCase.ABLATIVE);
+
+        String key = InflectionKey.buildAgreementKey(builder.build());
+        assertEquals("ABLATIVE|SINGULAR|MASCULINE|FEMININE|POSITIVE", key);
     }
 }

--- a/src/test/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/LexemeDetailControllerIntegrationTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/LexemeDetailControllerIntegrationTest.java
@@ -198,6 +198,30 @@ class LexemeDetailControllerIntegrationTest {
     }
 
     @Test
+    void gerundFormsAppearInDetailResponse() {
+        UUID lexemeId = new LexemeBuilder("sequor", PartOfSpeech.VERB, "1").build().getId();
+
+        String url = UriComponentsBuilder
+                .fromUriString(getFullBaseUrl())
+                .path(ApiRoutes.LEXEME_DETAIL)
+                .queryParam("type", "VERB")
+                .buildAndExpand(lexemeId)
+                .toUriString();
+
+        ResponseEntity<String> response = restClient.get().uri(url).retrieve().toEntity(String.class);
+        String body = response.getBody();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(body);
+        assertTrue(body.contains("\"defaultName\":\"Gerund\""));
+        assertTrue(body.contains("\"GENITIVE\":\"sequendī\""));
+        assertTrue(body.contains("\"DATIVE\":\"sequendō\""));
+        assertTrue(body.contains("\"ACCUSATIVE\":\"sequendum\""));
+        assertTrue(body.contains("\"ABLATIVE\":\"sequendō\""));
+        assertFalse(body.contains("\"gender\":null"));
+    }
+
+    @Test
     void testTypeMismatchReturnsConflict() {
         LexemeBuilder lexemeBuilder = new LexemeBuilder("poculum", PartOfSpeech.NOUN, "1");
         UUID lexemeId = lexemeBuilder.build().getId();

--- a/src/test/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ParticipleTableMapperTest.java
+++ b/src/test/java/com/annepolis/lexiconmeum/webapi/bff/lexemedetail/dtoassembly/inflection/ParticipleTableMapperTest.java
@@ -163,7 +163,7 @@ class ParticipleTableMapperTest {
         }
 
         VerbDetails details = ((VerbDetails) getTestLexeme().getPartOfSpeechDetails()).toBuilder()
-                .addParticipleSet(ParticipleDeclensionSet.Builder.forSupine("amātum")
+                .addParticipleSet(ParticipleDeclensionSet.Builder.forVerbalNoun(GrammaticalTense.SUPINE, "amātum")
                         .addInflection(accusativeBuilder.build())
                         .addInflection(ablativeBuilder.build())
                         .build())
@@ -189,6 +189,61 @@ class ParticipleTableMapperTest {
                             )
                     ),
                     supine.getDeclensions()
+            );
+        }
+    }
+
+    @Test
+    void gerundIsMappedInEachGenderedParticipleTable() {
+        Participle.Builder genitiveBuilder = new Participle.Builder("amandī")
+                .setGrammaticalCase(GrammaticalCase.GENITIVE);
+        Participle.Builder dativeBuilder = new Participle.Builder("amandō")
+                .setGrammaticalCase(GrammaticalCase.DATIVE);
+        Participle.Builder accusativeBuilder = new Participle.Builder("amandum")
+                .setGrammaticalCase(GrammaticalCase.ACCUSATIVE);
+        Participle.Builder ablativeBuilder = new Participle.Builder("amandō")
+                .setGrammaticalCase(GrammaticalCase.ABLATIVE);
+        for (GrammaticalGender gender : GrammaticalGender.values()) {
+            genitiveBuilder.addGender(gender);
+            dativeBuilder.addGender(gender);
+            accusativeBuilder.addGender(gender);
+            ablativeBuilder.addGender(gender);
+        }
+
+        VerbDetails details = ((VerbDetails) getTestLexeme().getPartOfSpeechDetails()).toBuilder()
+                .addParticipleSet(ParticipleDeclensionSet.Builder
+                        .forVerbalNoun(GrammaticalTense.GERUND, "amandum")
+                        .addInflection(genitiveBuilder.build())
+                        .addInflection(dativeBuilder.build())
+                        .addInflection(accusativeBuilder.build())
+                        .addInflection(ablativeBuilder.build())
+                        .build())
+                .build();
+        Lexeme lexeme = LexemeBuilder.fromLexeme(getTestLexeme())
+                .setPartOfSpeechDetails(details)
+                .build();
+
+        List<ParticipleTableDTO> tables = new ParticipleTableMapper().toInflectionTableDTO(lexeme);
+        for (ParticipleTableDTO table : tables) {
+            ParticipleTableDTO.ParticipleTenseDTO gerund = table.getTenses().get(table.getTenses().size() - 1);
+
+            assertEquals("Gerund", gerund.getDefaultName());
+            assertEquals(
+                    Map.of(
+                            GrammaticalNumber.SINGULAR, Map.of(
+                                    GrammaticalCase.GENITIVE, "amandī",
+                                    GrammaticalCase.DATIVE, "amandō",
+                                    GrammaticalCase.ACCUSATIVE, "amandum",
+                                    GrammaticalCase.ABLATIVE, "amandō"
+                            ),
+                            GrammaticalNumber.PLURAL, Map.of(
+                                    GrammaticalCase.GENITIVE, "amandī",
+                                    GrammaticalCase.DATIVE, "amandō",
+                                    GrammaticalCase.ACCUSATIVE, "amandum",
+                                    GrammaticalCase.ABLATIVE, "amandō"
+                            )
+                    ),
+                    gerund.getDeclensions()
             );
         }
     }


### PR DESCRIPTION
## Summary

- ingest Wiktionary gerund forms as verbal-noun declension sets
- generalize supine-specific model and key handling for verbal nouns
- expose gerund case forms in lexeme detail participle tables
- add unit and integration coverage

## Verification

- `./mvnw test` (311 tests passed)
- `./mvnw spotbugs:check` (0 findings)